### PR TITLE
corrected bug in EFieldSolver.cpp (rlog not resized)

### DIFF
--- a/src/Core/EFieldSolver.cpp
+++ b/src/Core/EFieldSolver.cpp
@@ -83,6 +83,7 @@ void EFieldSolver::shortRange(vector<Particle> *beam,vector<double> &ez, double 
    cmid.resize(ngrid);
    cupp.resize(ngrid);
    gam.resize(ngrid);
+   rlog.resize(ngrid);
   }
 
 


### PR DESCRIPTION
'rlog' vector in EFieldSolver.cpp (83) is not resized when  shortRange method is called. 
This result in an undefined behaviour when accessing rlog.
This patch correct such an issue.