### PR TITLE
put rpart = 0 for out of the grid particles

### DIFF
--- a/src/Core/BeamSolver.cpp
+++ b/src/Core/BeamSolver.cpp
@@ -78,7 +78,9 @@ void BeamSolver::advance(double delz, Beam *beam, vector< Field *> *field, Undul
            idx++;
            cpart+=field->at(nfld[ifld])->field[islice].at(idx)*(1-wx)*(1-wy);
            rpart[ifld]=rtmp[ifld]*awloc*conj(cpart);
-	  }
+	  } else {
+          rpart[ifld] = 0;
+      }
 	}
 	this->RungeKutta(delz);
 


### PR DESCRIPTION
In https://github.com/svenreiche/Genesis-1.3-Version4/blob/master/src/Core/BeamSolver.cpp#L68-L81

rpart is updated every time the evaluated particle is found to be on the grid. 
If the particle is not on the grid, it takes the values of the rpart elements set by the previous particle which, I think, it's an error. Am I wrong?    

Also for me, it's unclear if out-of-grid particles still need to be simulated at all or not.