### PR TITLE
fixed bug in harmonic upconversion screwing up vertical beam optics

### DIFF
--- a/src/Core/Beam.cpp
+++ b/src/Core/Beam.cpp
@@ -163,7 +163,7 @@ bool Beam::harmonicConversion(int harmonic, bool resample)
       p.x    =beam[i].at(j).x;
       p.y    =beam[i].at(j).y;
       p.px   =beam[i].at(j).px;
-      p.py   =beam[i].at(j).px;
+      p.py   =beam[i].at(j).py;
       beam[i*harmonic].push_back(p);
     }
     beam[i].clear(); 


### PR DESCRIPTION
Dear Sven,

I've found a bug in the harmonic up-conversion code of GENESIS4. The vertical optics got screwed up.

This should fix the issue.

Best
Christoph