### PR TITLE
G4 binary reports source code commit ID (info also stored in /Meta/Ve…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.o
 gencore
 lib
+
+build_info.c

--- a/Makefile
+++ b/Makefile
@@ -17,18 +17,25 @@ VPATH = src/Core src/IO src/Lattice src/Util src/Main src/Loading
 CCOMPILER = h5pcc
 #CCOMPILER = vtcxx -vt:cxx h5pcc -vt:inst manual -DVTRACE
 #
+#  flags
+#
+FLAGS = -O2
+# FLAGS = -g
+#
 #  executable name 
 #
 EXECUTABLE = gencore
 #
 # targets
 #
-OBJECTS = Sorting.o BesselJ.o Inverfc.o Hammerslay.o RandomU.o GaussHermite.o StringProcessing.o Track.o Setup.o AlterSetup.o Time.o Wake.o Parser.o Dump.o SponRad.o EField.o LoadBeam.o ImportBeam.o LoadField.o ImportField.o Profile.o Series.o ShotNoise.o QuietLoading.o Optics.o Lattice.o LatticeElements.o LatticeParser.o AlterLattice.o Gencore.o TrackBeam.o Control.o Field.o FieldSolver.o EFieldSolver.o Incoherent.o Collective.o Beam.o BeamSolver.o Undulator.o HDF5base.o readBeamHDF5.o writeBeamHDF5.o readFieldHDF5.o writeFieldHDF5.o SDDSBeam.o Output.o  GenMain.o 
+OBJECTS = Sorting.o BesselJ.o Inverfc.o Hammerslay.o RandomU.o GaussHermite.o StringProcessing.o Track.o Setup.o AlterSetup.o Time.o Wake.o Parser.o Dump.o SponRad.o EField.o LoadBeam.o ImportBeam.o LoadField.o ImportField.o Profile.o Series.o ShotNoise.o QuietLoading.o Optics.o Lattice.o LatticeElements.o LatticeParser.o AlterLattice.o Gencore.o TrackBeam.o Control.o Field.o FieldSolver.o EFieldSolver.o Incoherent.o Collective.o Beam.o BeamSolver.o Undulator.o HDF5base.o readBeamHDF5.o writeBeamHDF5.o readFieldHDF5.o writeFieldHDF5.o SDDSBeam.o Output.o  GenMain.o
 
-genesis:	$(OBJECTS)
+.PHONY: genesis genesisexecutable clean install beta
+
+genesis:	$(OBJECTS) build_info.o
 	ar -cvq libgenesis13.a $(OBJECTS)
 	mv libgenesis13.a ./lib
-	$(CCOMPILER) src/Main/mainwrap.cpp -o $(EXECUTABLE) $(INCLUDE) $(LIB) -lgenesis13 -Llib
+	$(CCOMPILER) src/Main/mainwrap.cpp build_info.o -o $(EXECUTABLE) $(INCLUDE) $(LIB) -lgenesis13 -Llib
 
 genesisexecutable:	$(OBJECTS)
 	$(CCOMPILER)  -o $(EXECUTABLE) $(OBJECTS) $(LIB)
@@ -36,7 +43,18 @@ genesisexecutable:	$(OBJECTS)
 
 
 .cpp.o:
-	$(CCOMPILER) -O2 -c $(DMACRO) $(INCLUDE) $<
+	$(CCOMPILER) $(FLAGS) -c $(DMACRO) $(INCLUDE) $<
+
+### rules for build info
+build_info.o: build_info.c
+	$(CCOMPILER) $(FLAGS) -c $<
+build_info.c: FORCE
+	rm -f build_info.c
+	./build_info.sh
+# so-called "force target", see GNU make manual "rules without recipes or prerequisites"
+FORCE:
+
+### end rules for build info
 
 clean:
 	rm -f src/Core/*~
@@ -48,6 +66,8 @@ clean:
 	rm -f include/*~
 	rm -f *.o
 	rm -f lib/*.a
+	rm -f build_info.o build_info.c
+	rm -f $(EXECUTABLE)
 
 install:
 	cp ./$(EXECUTABLE) ~/bin/genesis4

--- a/build_info.sh
+++ b/build_info.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# C. Lechner, DESY, 2020-Feb-16
+#
+# Generate C function that returns essential infos
+# about source code (git commit ID etc.) and build
+# as string.
+
+F=build_info.c
+
+rm -f $F
+
+
+echo -n > $F
+echo "const char *build_info(void) { " >> $F
+echo -n "const char *msg = \"" >> $F
+echo -n "compiled by " >> $F
+echo -n `whoami` >> $F
+echo -n " " >> $F
+echo -n `date "+%Y%m%dT%H%M"` >> $F
+echo -n " from git commit ID " >> $F
+git log --format="%H" -n 1 | tr -d '\n' >> $F
+
+# 20190223: "git status -s -u no" does not show the modified files?
+# Lines with untracked files begin with '??', ignore those.
+if [[ ! -z $(git status -s | grep --invert "^??") ]]; then
+	echo -n " (+ uncommitted changes)" >> $F
+fi
+
+echo "\";" >> $F
+echo "return(msg);" >> $F
+echo "}" >> $F

--- a/include/build_info.h
+++ b/include/build_info.h
@@ -1,0 +1,8 @@
+#ifndef __BUILD_INFO_H
+#define __BUILD_INFO_H
+
+extern "C" {
+	const char *build_info(void);
+}
+
+#endif

--- a/src/IO/Output.cpp
+++ b/src/IO/Output.cpp
@@ -10,6 +10,8 @@
 #include <fstream>
 #include <streambuf>
 
+#include "build_info.h"
+
 extern bool MPISingle;
 
 Output::Output(){
@@ -92,6 +94,8 @@ void Output::writeMeta()
   tmp[0]=0;
   if (versionbeta) { tmp[0]=1;}
   this->writeSingleNode(gidsub,"Beta"," ",&tmp);
+  string s_bi(build_info());
+  this->writeSingleNodeString(gidsub,"Build_Info", &s_bi);
   H5Gclose(gidsub);  
   
   time_t timer;

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -42,6 +42,7 @@
 #include "writeFieldHDF5.h"
 #include "Collective.h"
 #include "Wake.h"
+#include "build_info.h"
 
 #include <sstream>
 
@@ -85,7 +86,8 @@ double genmain (string mainstring, string latstring, string outstring, int in_se
           cout << "---------------------------------------------" << endl;
           cout << "GENESIS - Version " <<  versionmajor <<"."<< versionminor << "." << versionrevision ;
 	  if (versionbeta) {cout << " (beta)";}
-	  cout << " has started..." << endl;			
+	  cout << " has started..." << endl;
+          cout << "compile info: " << build_info() << endl;			
 	  cout << "Starting Time: " << ctime(&timer)<< endl;
           cout << "MPI-Comm Size: " << size << " nodes" << endl << endl;
         }


### PR DESCRIPTION
This patch includes information about source code (git commit ID) and build process itself (timestamp, user) into the binary. Info text is reported on start-up and also included into .out.h5 file as "/Meta/Version/Build_Info".