### PR TITLE
Fix wrong shebang in build_info.sh

### DIFF
--- a/build_info.sh
+++ b/build_info.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # C. Lechner, DESY, 2020-Feb-16
 #


### PR DESCRIPTION
The script is not posix shell compatible, but uses bash only syntax, thought the shebang requested only sh.