### PR TITLE
various fixes of memory leaks

### DIFF
--- a/include/LatticeElements.h
+++ b/include/LatticeElements.h
@@ -12,7 +12,7 @@ class Element
 {
  public:
   Element(){};
-  ~Element(){};
+  virtual ~Element(){};
   double z,l,zoff;
   string type;
      //enum LatticeElement type;

--- a/include/Sequence.h
+++ b/include/Sequence.h
@@ -11,6 +11,7 @@
 class Sequence
 {
 public:
+	virtual ~Sequence() {};
 	virtual double getElement() = 0;
 	virtual void set(unsigned int) = 0;
 };

--- a/src/Core/Control.cpp
+++ b/src/Core/Control.cpp
@@ -13,11 +13,13 @@
 Control::Control()
 {
   nwork=0;
+  work=NULL;
 }
 
 
 Control::~Control()
 {
+  delete[] work;
 }
 
 
@@ -156,8 +158,8 @@ void Control::applySlippage(double slippage, Field *field)
   field->accuslip+=slippage;
 
   // allocate working space
-
   if(nwork<field->ngrid*field->ngrid*2){
+    delete[] work;
     nwork=field->ngrid*field->ngrid*2;
     work=new double [nwork];
   } 

--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -13,11 +13,12 @@
 
 
 Field::~Field(){
-#ifdef FFTW                // release the working arrays for the FFTs
+#ifdef FFTW                // release the FFTW plan
   fftw_destroy_plan(p);
-  fftw_free(in);
-  fftw_free(out);
-#endif  
+#endif
+
+  delete[] in;
+  delete[] out;
 }
 
 Field::Field(){

--- a/src/Loading/QuietLoading.cpp
+++ b/src/Loading/QuietLoading.cpp
@@ -52,8 +52,9 @@ void QuietLoading::loadQuiet(Particle *beam, BeamSlice *slice, int npart, int nb
 
 
   // resets Hammersley sequence but does nothing for random sequence; 
-  Sequence *seed = (Sequence *) new RandomU(islice);
+  Sequence *seed = new RandomU(islice);
   int iseed=static_cast<int>(round(seed->getElement()*1e9));
+  delete seed;
 
   // initialize the sequence to new values to avoid that all core shave the same distribution
   st->set(iseed);

--- a/src/Main/AlterSetup.cpp
+++ b/src/Main/AlterSetup.cpp
@@ -130,6 +130,7 @@ bool AlterSetup::init(int inrank, map<string,string> *arg, Setup *setup, Lattice
 
 	} else {
 	    if (rank==0) {cout << "Deleting non-matching radiation harmonic: " << field->at(i)->getHarm() << " in harmonic conversion" << endl;}
+	    delete field->at(i);
 	    field->erase(field->begin()+i);
 	    i--; // reseting the count
         }

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -300,8 +300,14 @@ double genmain (string mainstring, string latstring, string outstring, int in_se
             cout << "*** Error: Unknow element in input file: " << element << endl; 
 	  }
           break;
-        } 
+        }
 
+
+
+
+        // release memory allocated for fields
+        for(int i=0; i<field.size(); i++)
+          delete field[i];
 
 
  	if (rank==0) {

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -303,7 +303,14 @@ double genmain (string mainstring, string latstring, string outstring, int in_se
         }
 
 
-
+        /*** clean up ***/
+        delete timewindow;
+        delete seq;
+        delete profile;
+        delete lattice;
+        delete alt;
+        delete setup;
+        delete beam;
 
         // release memory allocated for fields
         for(int i=0; i<field.size(); i++)


### PR DESCRIPTION
These changes fix various memory leaks. In particular, the memory holding the fields of the harmonics discarded during harmonic upconversion is properly released. Note that possible memory loss that might occur during subharmonic conversion (also here the discarded fields) was not fixed, yet.