### PR TITLE
additional output in .out.h5 (branch cl_20210313__globalstats)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CCOMPILER = h5pcc
 #  flags
 #
 FLAGS = -O2
-# FLAGS = -g
+# FLAGS = -g -O0
 #
 #  executable name
 #

--- a/include/Beam.h
+++ b/include/Beam.h
@@ -47,6 +47,7 @@ class Beam{
    // output buffer
    vector<double> zpos,gavg,gsig,xavg,xsig,yavg,ysig,pxavg,pyavg,bunch,bphi,efld;
    vector<double> bx,by,ax,ay,ex,ey,cu;
+   vector<unsigned long long> partcount;
    vector< vector<double> > bh,ph;  // harmonic bunching and bunching phase
    
  private:

--- a/include/Beam.h
+++ b/include/Beam.h
@@ -36,6 +36,8 @@ class Beam{
 
    void setBunchingHarmonicOutput(int harm_in);
    int getBunchingHarmonics();
+   void set_global_stat(bool);
+   bool get_global_stat(void);
 
    vector< vector<Particle> > beam;
    vector<double> current,eloss;
@@ -59,6 +61,7 @@ class Beam{
    Sorting sorting;
    int idx;
    int bharm;
+   bool do_global_stat;
 };
 
 inline void Beam::initIncoherent(int base, int rank, bool spread, bool loss){
@@ -84,6 +87,15 @@ inline void Beam::setBunchingHarmonicOutput(int harm_in)
 inline int Beam::getBunchingHarmonics()
 {
   return bharm;
+}
+
+inline void Beam::set_global_stat(bool in)
+{
+  do_global_stat=in;
+}
+inline bool Beam::get_global_stat(void)
+{
+  return(do_global_stat);
 }
 
 #endif

--- a/include/Beam.h
+++ b/include/Beam.h
@@ -49,6 +49,8 @@ class Beam{
    vector<double> bx,by,ax,ay,ex,ey,cu;
    vector<unsigned long long> partcount;
    vector< vector<double> > bh,ph;  // harmonic bunching and bunching phase
+
+   vector<double> tot_gmean, tot_gstd;
    
  private:
    BeamSolver solver;

--- a/include/HDF5base.h
+++ b/include/HDF5base.h
@@ -30,6 +30,7 @@ class HDF5Base{
   
   // function from output and wrideHDF5beam/field
   void writeBuffer(hid_t,string,string,vector<double> *);
+  void writeBufferULL(hid_t,string,string,vector<unsigned long long> *);
   void writeSingleNode(hid_t,string,string,vector<double> *);
   void writeSingleNodeString(hid_t,string, string *);
   void writeSingleNodeInt(hid_t, string,vector<int> *);

--- a/include/Setup.h
+++ b/include/Setup.h
@@ -30,6 +30,7 @@ class Setup: public StringProcessing{
    void   setStepLength(double);
    bool   getOne4One();
    bool   getShotNoise();
+   bool   getBeamGlobalStat();
    int    getNpart();
    int    getNbins();
    int    getSeed();
@@ -45,6 +46,7 @@ class Setup: public StringProcessing{
    string rootname,lattice,beamline,partfile,fieldfile;
    double gamma0,lambda0,delz;
    bool one4one,shotnoise;
+   bool beam_global_stat;
    int seed, rank,npart,nbins,runcount;
 };
 
@@ -54,6 +56,7 @@ inline void   Setup::setReferenceLength(double lam){ lambda0=lam; return; }
 inline double Setup::getReferenceEnergy(){ return gamma0; }
 inline bool   Setup::getOne4One(){return one4one;}
 inline bool   Setup::getShotNoise(){return shotnoise;}
+inline bool   Setup::getBeamGlobalStat(){return beam_global_stat;}
 inline int    Setup::getNpart(){return npart;}
 inline int    Setup::getNbins(){return nbins;}
 inline int    Setup::getSeed(){return seed;}

--- a/src/Core/Beam.cpp
+++ b/src/Core/Beam.cpp
@@ -49,6 +49,7 @@ void Beam::initDiagnostics(int nz)
   bunch.resize(nz*ns); 
   bphi.resize(nz*ns);
   efld.resize(nz*ns);
+  partcount.resize(nz*ns);
 
   bx.resize(ns);
   by.resize(ns);
@@ -307,6 +308,7 @@ void Beam::diagnostics(bool output, double z)
     bunch[ioff+is]=bbavg;
     bphi[ioff+is]=bbphi;
     efld[ioff+is]=eloss[is];  
+    partcount[ioff+is]=nsize;
 
     for (int ih=1; ih<bharm;ih++){   // calculate the harmonics of the bunching
       br=0;

--- a/src/IO/Output.cpp
+++ b/src/IO/Output.cpp
@@ -203,11 +203,9 @@ void Output::writeLattice(Beam * beam,Undulator *und)
 
 void Output::writeBeamBuffer(Beam *beam)
 {
-
-
+  hid_t gid, gidsub;
 
   // step 1 - create the group
-  hid_t gid;
   gid=H5Gcreate(fid,"Beam",H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
 
   // step 2 - write individual datasets
@@ -242,8 +240,14 @@ void Output::writeBeamBuffer(Beam *beam)
     this->writeBuffer(gid, bgroup,"rad",  &beam->ph[i-1]);
     }
 
-  // step 3 - close group and done
 
+  gidsub=H5Gcreate(gid,"Global",H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
+  this->writeSingleNode(gidsub,"energy"," ", &beam->tot_gmean);
+  this->writeSingleNode(gidsub,"energyspread"," ", &beam->tot_gstd);
+  H5Gclose(gidsub);  
+  
+
+  // step 3 - close group and done
   H5Gclose(gid);
 
   return;

--- a/src/IO/Output.cpp
+++ b/src/IO/Output.cpp
@@ -240,11 +240,12 @@ void Output::writeBeamBuffer(Beam *beam)
     this->writeBuffer(gid, bgroup,"rad",  &beam->ph[i-1]);
     }
 
-
-  gidsub=H5Gcreate(gid,"Global",H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
-  this->writeSingleNode(gidsub,"energy"," ", &beam->tot_gmean);
-  this->writeSingleNode(gidsub,"energyspread"," ", &beam->tot_gstd);
-  H5Gclose(gidsub);  
+  if(beam->get_global_stat()) {
+    gidsub=H5Gcreate(gid,"Global",H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
+    this->writeSingleNode(gidsub,"energy"," ", &beam->tot_gmean);
+    this->writeSingleNode(gidsub,"energyspread"," ", &beam->tot_gstd);
+    H5Gclose(gidsub);  
+  }
   
 
   // step 3 - close group and done

--- a/src/IO/Output.cpp
+++ b/src/IO/Output.cpp
@@ -222,6 +222,8 @@ void Output::writeBeamBuffer(Beam *beam)
   this->writeBuffer(gid, "bunching"," ",&beam->bunch);
   this->writeBuffer(gid, "bunchingphase","rad", &beam->bphi);
   this->writeBuffer(gid, "efield","eV/m", &beam->efld);
+  this->writeBufferULL(gid, "npart_in_slice"," ", &beam->partcount); // HDF5 warnings pop up in function writeBufferULL if unit=""
+
   
   this->writeBuffer(gid, "betax","m",&beam->bx);
   this->writeBuffer(gid, "betay","m",&beam->by);

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -297,7 +297,7 @@ double genmain (string mainstring, string latstring, string outstring, int in_se
           // error because the element typ is not defined
 
           if (rank==0){
-            cout << "*** Error: Unknow element in input file: " << element << endl; 
+            cout << "*** Error: Unknown element in input file: " << element << endl; 
 	  }
           break;
         } 

--- a/src/Main/Setup.cpp
+++ b/src/Main/Setup.cpp
@@ -16,7 +16,9 @@ Setup::Setup()
   lambda0=1e-10;
   delz=0.015; 
   seed=123456789;
-  runcount = 0 ;  // count of runs in conjunction of calls of altersetup 
+  beam_global_stat=false;
+
+  runcount = 0 ;  // count of runs in conjunction of calls of altersetup
 }
 
 Setup::~Setup(){}
@@ -36,6 +38,7 @@ void Setup::usage(){
   cout << " int nbins = 4" << endl;
   cout << " bool one4one = false" << endl;
   cout << " bool shotnoise = true" << endl;
+  cout << " bool beam_global_stat = false" << endl;
   cout << "&end" << endl << endl;
   return;
 }
@@ -62,6 +65,7 @@ bool Setup::init(int inrank, map<string,string> *arg, Lattice *lat,string latstr
   if (arg->find("npart")!=end)    {npart  = atoi(arg->at("npart").c_str());  arg->erase(arg->find("npart"));}
   if (arg->find("nbins")!=end)    {nbins  = atoi(arg->at("nbins").c_str());  arg->erase(arg->find("nbins"));}
   if (arg->find("shotnoise")!=end){shotnoise  = atob(arg->at("shotnoise"));  arg->erase(arg->find("shotnoise"));}
+  if (arg->find("beam_global_stat")!=end) {beam_global_stat = atob(arg->at("beam_global_stat"));  arg->erase(arg->find("beam_global_stat"));}
 
   if (arg->size()!=0){
     if (rank==0){ cout << "*** Error: Unknown elements in &setup" << endl; this->usage();}
@@ -69,8 +73,19 @@ bool Setup::init(int inrank, map<string,string> *arg, Lattice *lat,string latstr
   }
 
 
-  if (one4one) {
+  if (one4one)
+  {
     nbins = 1;
+  }
+  else
+  {
+    // global beam statistics only reasonable for one4one mode
+    if(beam_global_stat) {
+      if(rank==0) {
+        cout << "one4one=0 => forcing beam_global_stat off" << endl;
+      }
+      beam_global_stat=false;
+    }
   }
 
   lat->parse(lattice,beamline,rank);

--- a/src/Main/Track.cpp
+++ b/src/Main/Track.cpp
@@ -75,8 +75,9 @@ bool Track::init(int inrank, int insize, map<string,string> *arg, Beam *beam, ve
   und->updateMarker(dumpFieldStep,dumpBeamStep,sort_step,zstop);
 
   beam->setBunchingHarmonicOutput(bunchharm);
-  // call to gencore to do the actual tracking.  
+  beam->set_global_stat(setup->getBeamGlobalStat());
 
+  // call to gencore to do the actual tracking.  
   Gencore core;
   core.run(file.c_str(),beam,field,und,isTime,isScan);
 


### PR DESCRIPTION
Two new features:
1) Write evolution of particle distribution to .out.h5: In one4one simulations, generate additional dataset  "/Beam/npart_in_slice" in .out.h5 file, containing for every integration step the number of particles per slice. This data describes the evolution of the current profile along the undulator, enabling better interpretation of the other fields in "/Beam/...".
2) Global statistics of energy spread + mean energy: If requested by setting the new flag beam_global_stat=true in &setup block (default value is false, i.e. OFF), the energy spread (and mean energy) of the entire beam are reported as datasets "/Beam/Global/energy" and "/Beam/Global/energyspread" for every integration step. Documentation in manual will follow.