### PR TITLE
Fix Compile & Linker 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OBJECTS = Sorting.o BesselJ.o Inverfc.o Hammerslay.o RandomU.o GaussHermite.o St
 .PHONY: genesis genesisexecutable clean install beta
 
 genesis:	$(OBJECTS) build_info.o
-	ar -cvq libgenesis13.a $(OBJECTS)
+	ar -cvq libgenesis13.a $(OBJECTS) build_info.o
 	mv libgenesis13.a ./lib
 	$(CCOMPILER) src/Main/mainwrap.cpp build_info.o -o $(EXECUTABLE) $(INCLUDE) $(LIB) -lgenesis13 -Llib
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ genesisexecutable:	$(OBJECTS)
 
 ### rules for build info
 build_info.o: build_info.c
-	$(CCOMPILER) $(FLAGS) -c $<
+	$(CCOMPILER) $(FLAGS) $(INCLUDE) -c $<
 build_info.c: FORCE
 	rm -f build_info.c
 	./build_info.sh

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ OBJECTS = Sorting.o BesselJ.o Inverfc.o Hammerslay.o RandomU.o GaussHermite.o St
 genesis:	$(OBJECTS) build_info.o
 	ar -cvq libgenesis13.a $(OBJECTS) build_info.o
 	mv libgenesis13.a ./lib
-	$(CCOMPILER) src/Main/mainwrap.cpp build_info.o -o $(EXECUTABLE) $(INCLUDE) $(LIB) -lgenesis13 -Llib
+	$(CCOMPILER) src/Main/mainwrap.cpp -o $(EXECUTABLE) $(INCLUDE) -lgenesis13 -Llib $(LIB)
 
 genesisexecutable:	$(OBJECTS)
 	$(CCOMPILER)  -o $(EXECUTABLE) $(OBJECTS) $(LIB)

--- a/build_info.sh
+++ b/build_info.sh
@@ -12,6 +12,7 @@ rm -f $F
 
 
 echo -n > $F
+echo "#include \"build_info.h\"" >> $F
 echo "const char *build_info(void) { " >> $F
 echo -n "const char *msg = \"" >> $F
 echo -n "compiled by " >> $F

--- a/include/Track.h
+++ b/include/Track.h
@@ -8,8 +8,8 @@
 #include <map>
 #include <stdlib.h>
 
-#include "hdf5.h"
-#include "mpi.h"
+#include <hdf5.h>
+#include <mpi.h>
 
 #include "Setup.h"
 #include "Lattice.h"

--- a/src/Main/mainwrap.cpp
+++ b/src/Main/mainwrap.cpp
@@ -1,5 +1,10 @@
-#include <cstdlib>
 #include "genesis.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
+using namespace std;
 
 // very basic wrapper for genesis. Most of the genesis stuff is moved into genmain.
 


### PR DESCRIPTION
This fixes a couple of compiler & linker problems when getting started with Genesis.


- `build_info`: boundle into library
  - avoids needing to care about link order (left-to-right)
- `build_info`: fix symbol error
  - add declaration via include file
- `Makefile`: Fix Link Object Order
  - The order of objects and libs in the linker line matters: from left-to-right, the next command will always fill in the
symbols marked as missing on the left. This fixes various linker errors.
- `Track.h`: mpi & hdf5 are "system"
  - External "system"-provided (or package manager provided) libs should be included with `<>` to avoid include/compiler errors.
- `mainwrap`: missing includes & namespace
  - Fix compile errors:
    - missing stdlib includes that are used
    - missing implied `std` namespace use


