### PR TITLE
fix compiler error caused by build_info.h

### DIFF
--- a/include/build_info.h
+++ b/include/build_info.h
@@ -1,8 +1,9 @@
 #ifndef __BUILD_INFO_H
 #define __BUILD_INFO_H
 
-extern "C" {
-	const char *build_info(void);
-}
+#ifdef __cplusplus
+extern "C" /* effective only for C++ compilers, declaration continues after #endif */
+#endif
+const char *build_info(void);
 
 #endif


### PR DESCRIPTION
'extern "C"' is now only visible to C++ compilers, fixing compilation
issues with updated Makefile.

Tested on Ubuntu 16.04LTS and CentOS 7.9.2009 Core (using gcc v8).