### PR TITLE
fixed potentially uninitialized value of shotnoise seed

### DIFF
--- a/src/Main/mainwrap.cpp
+++ b/src/Main/mainwrap.cpp
@@ -24,7 +24,7 @@ int main (int argc, char *argv[]) {
       	string filename (argv[argc-1]);  // input file is always last element
 	string latname  ("");
 	string outname  ("");
-	int    seed;
+	int    seed = 123456789;
 	
 	bool ok=true;
 


### PR DESCRIPTION
If the shotnoise seed is neither explicitly assigned in &setup nor
set by using the "-s" command line option, an undefined seed value
was used (uninitialized variable). This patch fixes this issue, the
seed defaults then to the value described in the manual (&setup section).