### PR TITLE
"profile_file_multi" namelist // additional data checks in "profile_file"

### DIFF
--- a/include/Profile.h
+++ b/include/Profile.h
@@ -92,6 +92,29 @@ class ProfileFile : public ProfileBase, StringProcessing, HDF5Base
   vector<double> xdat,ydat;
 };
 
+class ProfileFileMulti: public StringProcessing, HDF5Base /* cannot get interpolated value from this class: ProfileBase is not a base class */
+{
+public:
+	ProfileFileMulti(){};
+	~ProfileFileMulti(){};
+	bool setup(int, map<string, string> *, map<string, ProfileBase *> *);
+	void usage();
+};
+
+class ProfileInterpolator: public ProfileBase
+{
+public:
+	ProfileInterpolator(string, vector<double> *, vector<double> *);
+	~ProfileInterpolator();
+	double value(double);
+	string init(int, map<string,string> *);
+	void usage();
+
+private:
+	vector<double> xdat_, ydat_;
+	string label_;
+};
+
 
 //-------------------------
 

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -174,8 +174,9 @@ double genmain (string mainstring, string latstring, string outstring, int in_se
           if ((element.compare("&profile_const")==0)||
               (element.compare("&profile_gauss")==0)||
               (element.compare("&profile_file")==0)||
+              (element.compare("&profile_file_multi")==0) ||
               (element.compare("&profile_polynom")==0)||
-              (element.compare("&profile_step")==0)){            
+              (element.compare("&profile_step")==0)){
             if (!profile->init(rank,&argument,element)){ break; }
             continue;
 	  }


### PR DESCRIPTION
profile_file_multi:
Allows to define multiple profiles from a single .h5 file, all sharing the same xdata. The profile names are generated automatically from a user-specified prefix and the name of the respective hdf5 objects containing the vertical data. Therefore one can replace multiple "profile_file" namelists with a single "profile_file_multi" namelist, which results in significantly shorter input files when the slice parameters of beams and/or fields are defined by data from hdf5 files.

Example:
&profile_file_multi
   file = beam.h5
   xdata = s
   ydata = gamma, delgam, current
   label_prefix = prof
&end
==> The profiles "prof.gamma", "prof.delgam", and "prof.current" are generated.


Implemented additional checks in "profile_file" code, to ensure that
* 'x'/'y' data from file has identical size
* 'x' data is sorted