### PR TITLE
fix two minor compilation issues

### DIFF
--- a/src/Core/Undulator.cpp
+++ b/src/Core/Undulator.cpp
@@ -82,7 +82,7 @@ void Undulator::reportLattice(string fn_report)
   ofstream fo;
   int nz=aw.size(); /* aw is one element shorter than marker (as of git commit 1a9d191), see Lattice::generateLattice */
 
-  fo.open(fn_report);
+  fo.open(fn_report.c_str());
   fo << "i,z,aw,qf,marker,marker_decoded" << endl;
   for (int i=0;i<nz;i++)
   {

--- a/src/Lattice/Lattice.cpp
+++ b/src/Lattice/Lattice.cpp
@@ -508,7 +508,7 @@ void Lattice::report(string fn_report)
   ofstream fo;
   int nz=lat_aw.size();
 
-  fo.open(fn_report);
+  fo.open(fn_report.c_str());
   fo << "i,lat_z,lat_aw,lat_qf,lat_mk,lat_mk_decoded" << endl;
   for (int i=0;i<nz;i++)
   {


### PR DESCRIPTION
Fixes compilation error with older gcc version 4.8.5 when using compiler settings "-O2" or "-O0 -g" (= not requesting specific version of C++ standard).