### PR TITLE
modular electron beam diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ CCOMPILER = h5pcc
 #
 #  flags
 #
-#FLAGS = -O2
-FLAGS = -g -O2
+FLAGS = -O2
+# FLAGS = -g -O0
 #
 #  executable name
 #
@@ -34,7 +34,7 @@ EXECUTABLE = gencore
 #
 # targets
 #
-OBJECTS = Sorting.o BesselJ.o Inverfc.o Hammerslay.o RandomU.o GaussHermite.o StringProcessing.o Track.o Setup.o AlterSetup.o Time.o Wake.o Parser.o Dump.o SponRad.o EField.o LoadBeam.o ImportBeam.o LoadField.o ImportField.o Profile.o Series.o ShotNoise.o QuietLoading.o Optics.o Lattice.o LatticeElements.o LatticeParser.o AlterLattice.o Gencore.o TrackBeam.o Control.o Field.o FieldSolver.o EFieldSolver.o Incoherent.o Collective.o Beam.o BeamSolver.o Undulator.o HDF5base.o readBeamHDF5.o writeBeamHDF5.o readFieldHDF5.o writeFieldHDF5.o SDDSBeam.o Output.o GenMain.o VersionInfo.o
+OBJECTS = Sorting.o BesselJ.o Inverfc.o Hammerslay.o RandomU.o GaussHermite.o StringProcessing.o Track.o Setup.o AlterSetup.o Time.o Wake.o Parser.o Dump.o SponRad.o EField.o LoadBeam.o ImportBeam.o LoadField.o ImportField.o Profile.o Series.o ShotNoise.o QuietLoading.o Optics.o Lattice.o LatticeElements.o LatticeParser.o AlterLattice.o Gencore.o TrackBeam.o Control.o Field.o FieldSolver.o EFieldSolver.o Incoherent.o Collective.o Beam.o BeamDiag.o BeamDiag_Std.o BeamDiag_Demo.o BeamDiag_HDF5helper.o BeamSolver.o Undulator.o HDF5base.o readBeamHDF5.o writeBeamHDF5.o readFieldHDF5.o writeFieldHDF5.o SDDSBeam.o Output.o GenMain.o VersionInfo.o
 
 .PHONY: genesis genesisexecutable clean install beta
 

--- a/include/Beam.h
+++ b/include/Beam.h
@@ -11,10 +11,13 @@
 #include "Incoherent.h"
 #include "Sorting.h"
 #include "Collective.h"
+#include "BeamDiag.h"
 
 using namespace std;
 
 extern const double ce;
+
+class BeamDiag_Std;
 
 class Beam{
  public:
@@ -22,7 +25,7 @@ class Beam{
    virtual ~Beam();
    void initDiagnostics(int);
    void diagnostics(bool,double);
-   void diagnosticsStart();
+   // void diagnosticsStart();
    void init(int, int, double,double, double,bool);
    void initSorting(int,int,bool,bool);
    void initEField(double,int,int,int,double);
@@ -32,21 +35,19 @@ class Beam{
    bool subharmonicConversion(int,bool);
    int sort();
    void track(double, vector<Field *> *, Undulator *);
-   void setOutput(bool,bool,bool,bool);
+
    void setWriteFilter(bool,int,int,int);
    bool get_WriteFilter_active();
    int  get_WriteFilter_from();
    int  get_WriteFilter_to();
    int  get_WriteFilter_inc();
 
-   void setBunchingHarmonicOutput(int harm_in);
-   int getBunchingHarmonics();
-   void set_global_stat(bool);
-   bool get_global_stat(void);
-   bool outputCurrent();
-   bool outputAux();
-   bool outputEnergy();
-   bool outputSpatial();
+
+   void register_beam_diag(BeamDiag *);
+   void clear_beam_diag(void);
+   void beam_diag_store_results(hid_t);
+   void beam_diag_list_registered(void);
+   BeamDiag_Std *bd_std; // this pointer is currently needed for first call to function replacing Beam::diagnosticsStart from Control::init
 
    vector< vector<Particle> > beam;
    vector<double> current,eloss;
@@ -55,33 +56,20 @@ class Beam{
    bool one4one;     // flag whether one4one simulation is done
    int nbins;
 
-   // output buffer
-   vector<double> zpos,gavg,gsig,xavg,xsig,yavg,ysig,pxavg,pyavg,bunch,bphi,efld;
-   vector<double> bx,by,ax,ay,ex,ey,cu;
-   //   vector<unsigned long long> partcount;
-   vector< vector<double> > bh,ph;  // harmonic bunching and bunching phase
-
-   //global values
-   vector<double> tgavg, tgsig, txavg,txsig,tyavg, tysig,tbun;  // global values, averaging over the entire beam 
-   
- private:
+private:
    BeamSolver solver;
    Incoherent incoherent;
    Collective col;
    Sorting sorting;
    int idx;
-   int bharm;
-   bool do_global_stat;
-   bool doCurrent, doSpatial, doEnergy, doAux;
 
    bool beam_write_filter;
    int beam_write_slices_from, beam_write_slices_to, beam_write_slices_inc;
-};
 
-inline bool Beam::outputCurrent(){ return doCurrent;}
-inline bool Beam::outputSpatial(){ return doSpatial;}
-inline bool Beam::outputEnergy(){ return doEnergy;}
-inline bool Beam::outputAux(){ return doAux;}
+   vector<BeamDiag *> diaghooks;
+   bool can_change_diaghooks;
+   void beam_diag_do_diag(double);
+};
 
 inline void Beam::initIncoherent(int base, int rank, bool spread, bool loss){
   incoherent.init(base,rank,spread,loss);
@@ -96,18 +84,6 @@ inline void Beam::initEField(double rmax, int ngrid, int nz, int nphi, double la
 inline void Beam::initWake(unsigned int ns, unsigned int nsNode, double ds, double *wakeext, double *wakeres, double *wakegeo,double *wakerou, double ztrans, double radius, bool transient){
   col.initWake(ns, nsNode, ds, wakeext, wakeres, wakegeo, wakerou, ztrans, radius, transient);
 }
-
-
-inline void Beam::setBunchingHarmonicOutput(int harm_in){bharm=harm_in;}
-inline int Beam::getBunchingHarmonics(){return bharm;}
-inline void Beam::set_global_stat(bool in){do_global_stat=in;}
-inline bool Beam::get_global_stat(void){return(do_global_stat);}
-inline void Beam::setOutput(bool noCurrent_in, bool noEnergy_in, bool noSpatial_in, bool noAux_in) {
-  doCurrent = !noCurrent_in;
-  doSpatial = !noSpatial_in;
-  doEnergy = !noEnergy_in;
-  doAux = !noAux_in;
-}
 inline void Beam::setWriteFilter(bool in_active, int in_from, int in_to, int in_inc) {
    beam_write_filter = in_active;
    beam_write_slices_from = in_from;
@@ -118,4 +94,5 @@ inline bool Beam::get_WriteFilter_active() { return beam_write_filter; }
 inline int  Beam::get_WriteFilter_from()   { return beam_write_slices_from; }
 inline int  Beam::get_WriteFilter_to()     { return beam_write_slices_to; }
 inline int  Beam::get_WriteFilter_inc()    { return beam_write_slices_inc; }
+
 #endif

--- a/include/BeamDiag.h
+++ b/include/BeamDiag.h
@@ -1,0 +1,24 @@
+#ifndef __GEN_BEAMDIAG_H
+#define __GEN_BEAMDIAG_H
+
+#include <iostream>
+#include <hdf5.h>
+
+// including "Beam.h" does not give working definition of class Beam,
+// as this include file includes this file in turn
+class Beam;
+
+class BeamDiag {
+public:
+	BeamDiag();
+	virtual ~BeamDiag();
+
+	virtual void init(int nz, int ns)=0;
+	virtual void do_diag(const Beam *, double)=0;
+	virtual void output(hid_t parentobj)=0;
+
+	virtual std::string to_str(void) const;
+};
+std::ostream& operator<< (std::ostream&, const BeamDiag&);
+
+#endif // __GEN_BEAMDIAG_H

--- a/include/BeamDiag_Demo.h
+++ b/include/BeamDiag_Demo.h
@@ -1,0 +1,42 @@
+#ifndef __GEN_BEAMDIAG_DEMO
+#define __GEN_BEAMDIAG_DEMO
+
+#include <vector>
+
+#include "BeamDiag.h"
+#include "Beam.h"
+
+using namespace std;
+
+// Note that class HDF5Base adds lots of objects
+//                                    vvvvvvvvvvvvvvv
+class BeamDiag_Demo: public BeamDiag, public HDF5Base {
+public:
+	BeamDiag_Demo();
+	~BeamDiag_Demo();
+
+	void init(int nz, int ns);
+	void do_diag(const Beam *, double);
+	void output(hid_t parentobj);
+	std::string to_str(void) const;
+
+	// functions specific to this BeamDiag implementation
+	void config(unsigned long long);
+	void set_verbose(bool);
+
+private:
+	vector<unsigned long long> demodiag_data_;
+
+	int ns_;
+	int idx_;
+
+	bool is_initialized_;
+	bool is_configured_;
+	unsigned long long param_x_;
+
+	bool verbose_;
+
+	int my_rank_;
+};
+
+#endif // __GEN_BEAMDIAG_DEMO

--- a/include/BeamDiag_HDF5helper.h
+++ b/include/BeamDiag_HDF5helper.h
@@ -1,0 +1,20 @@
+#ifndef __GEN4_BEAMDIAG_HDF5HELPER
+#define __GEN4_BEAMDIAG_HDF5HELPER
+
+#include "HDF5base.h"
+
+using namespace std;
+
+class BeamDiag_HDF5Helper: public HDF5Base {
+public:
+	BeamDiag_HDF5Helper();
+	~BeamDiag_HDF5Helper();
+
+	void set_s0(int);
+	void set_ds(int);
+
+	using HDF5Base::writeSingleNode;
+	using HDF5Base::writeBuffer;
+};
+
+#endif //  __GEN4_BEAMDIAG_HDF5HELPER

--- a/include/BeamDiag_Std.h
+++ b/include/BeamDiag_Std.h
@@ -1,0 +1,63 @@
+#ifndef __GEN_BEAMDIAG_STD
+#define __GEN_BEAMDIAG_STD
+
+#include <vector>
+
+#include "BeamDiag.h"
+#include "Beam.h"
+
+using namespace std;
+
+// Note that class HDF5Base adds lots of objects
+//                                    vvvvvvvvvvvvvvv
+class BeamDiag_Std: public BeamDiag {
+public:
+	BeamDiag_Std();
+	~BeamDiag_Std();
+
+	void init(int nz, int ns);
+	void do_diag(const Beam *, double);
+	void output(hid_t parentobj);
+	std::string to_str(void) const;
+
+	// functions specific to this BeamDiag implementation
+	void do_initial_diag(const Beam *);
+
+	void setBunchingHarmonicOutput(int);
+	int getBunchingHarmonics(void);
+	void set_global_stat(bool);
+	bool get_global_stat(void);
+	void setOutput(bool, bool, bool, bool);
+
+
+	/* former member of class Beam (only member that is 'public' because Output::writeLattice needs access) */
+	vector<double> zpos;
+
+private:
+	/* former members of class Beam */
+	// output buffer
+	vector<double> gavg,gsig,xavg,xsig,yavg,ysig,pxavg,pyavg,bunch,bphi,efld;
+	vector<double> bx,by,ax,ay,ex,ey,cu;
+	//   vector<unsigned long long> partcount;
+	vector< vector<double> > bh,ph;  // harmonic bunching and bunching phase
+	//global values
+	vector<double> tgavg, tgsig, txavg,txsig,tyavg, tysig,tbun;  // global values, averaging over the entire beam 
+
+
+   int bharm;
+   bool do_global_stat;
+   bool doCurrent, doSpatial, doEnergy, doAux;
+
+
+
+	int ns_;
+	int idx_;
+
+	bool is_initialized_;
+	bool is_configured_;
+	bool verbose_;
+
+	int my_rank_;
+};
+
+#endif // __GEN_BEAMDIAG_STD

--- a/manual/modular_beam_diag.txt
+++ b/manual/modular_beam_diag.txt
@@ -1,0 +1,39 @@
+==============================
+== Modular Beam Diagnostics ==
+==============================
+Christoph Lechner, European XFEL, 2021-Nov
+
+This document summarizes a few key properties of the new modular
+diagnostics architecture. This architecture is still under development,
+therefore the code might still be modified in the future.
+
+Note that there is a demo diagnostics class in BeamDiag_Demo.cpp.
+
+With this architecture, adding additional diagnostics capabilities
+only requires a few additional lines of code in the function implementing
+the &track command (in src/Main/Track.cpp). The code implementing the
+additional diagnostics capability can be implemented in a single class
+based on the abstract base class 'BeamDiag'. Modifications to Beam.cpp,
+Output.cpp, or other source files are typically not required.
+Moreover, no additional member variables need to be added to class 'Beam'.
+All configuration parameters needed to set up the diagnostics module
+can be local variables in function Track::init, as their value will be
+stored directly in the diagnostics class.
+
+All diagnostics classes are based on the abstract based class 'BeamDiag'.
+This is the interface that needs to be implemented:
+* Function 'init' is called from Beam::initDiagnostics and prepares the
+  class instance, in particular setting up required memory
+* When the beam is to be diagnosed, function 'do_diag' is called
+* Data is written to the .out.h5 file by invoking function 'output'
+For configuration purposes, additional functions have to be implemented.
+
+This is the typical life cycle of the diagnostics objects:
+1) Modules are generated and configured in Track.cpp (code implementing
+   the &track command)
+2) The modules are registered with the instance of class 'Beam'
+3) Actual tracking process is started (call to function 'run' in class
+   'Gencore')
+3a) In function Gencore::run, also the output data is written
+4) The beam diagnostics objects are destroyed, as the 'Beam' instance
+   will be reused for the next &track command

--- a/src/Core/Beam.cpp
+++ b/src/Core/Beam.cpp
@@ -2,19 +2,17 @@
 #include "Field.h"
 #include "Sorting.h"
 
+#include "BeamDiag.h"
 
 Beam::~Beam(){}
 Beam::Beam(){
-  do_global_stat=false;
-  doCurrent=false;
-  doSpatial=true;
-  doEnergy=true;
-  doAux=true;
-
   beam_write_filter=false;
   beam_write_slices_from=-1;
   beam_write_slices_to=-1;
   beam_write_slices_inc=1;
+
+  bd_std=NULL;
+  can_change_diaghooks=true;
 }
 
 void Beam::init(int nsize, int nbins_in, double reflen_in, double slicelen_in, double s0_in, bool one4one_in )
@@ -25,7 +23,6 @@ void Beam::init(int nsize, int nbins_in, double reflen_in, double slicelen_in, d
   slicelength=slicelen_in;  // reflength times samplerate.
   s0=s0_in;
   one4one=one4one_in;
-  do_global_stat=false;
 
   current.resize(nsize);
   eloss.resize(nsize);
@@ -38,86 +35,50 @@ void Beam::init(int nsize, int nbins_in, double reflen_in, double slicelen_in, d
   return;
 }
 
+/*** Start: Code for modular beam diagnostics ***/
+void Beam::register_beam_diag(BeamDiag *bd) {
+	if(can_change_diaghooks)
+		diaghooks.push_back(bd);
+	else {
+		cout << "*** Error in Beam::register_beam_diag: cannot hook additional diagnostics after calling initDiagnostics ***" << endl;
+	}
+}
+void Beam::clear_beam_diag(void) {
+	for (unsigned int k=0; k<diaghooks.size(); k++)
+		delete diaghooks.at(k);
 
+	diaghooks.clear();
 
+	can_change_diaghooks=true;
+}
+void Beam::beam_diag_do_diag(double z) {
+	for(unsigned int k=0; k<diaghooks.size(); k++) {
+		diaghooks.at(k)->do_diag(this, z);
+	}
+}
+void Beam::beam_diag_store_results(hid_t parentobj) {
+	for(unsigned int k=0; k<diaghooks.size(); k++) {
+		diaghooks.at(k)->output(parentobj);
+	}
+}
+void Beam::beam_diag_list_registered(void) {
+	cout << "Listing diagnostics currently registered in this Beam instance" << endl;
+	for(unsigned int k=0; k<diaghooks.size(); k++) {
+		cout << "   element " << k << ": " << *(diaghooks.at(k)) << endl;
+	}
+	cout << "   (end of list)" << endl;
+}
+/*** End: Code for modular beam diagnostics ***/
 
 void Beam::initDiagnostics(int nz)
 {
-  
   idx=0;
   int ns=current.size();
-  zpos.resize(nz);
-  if (doSpatial){
-    xavg.resize(nz*ns);
-    xsig.resize(nz*ns);
-    yavg.resize(nz*ns);
-    ysig.resize(nz*ns);
-    pxavg.resize(nz*ns);
-    pyavg.resize(nz*ns);
-  } else {
-    xavg.resize(0);
-    xsig.resize(0);
-    yavg.resize(0);
-    ysig.resize(0);
-    pxavg.resize(0);
-    pyavg.resize(0);
-  }
-  if (doEnergy) {
-    gavg.resize(nz*ns);
-    gsig.resize(nz*ns);
-  } else {
-    gavg.resize(0);
-    gsig.resize(0);
-  }
-  bunch.resize(nz*ns); 
-  bphi.resize(nz*ns);
-  if (doAux){
-    efld.resize(nz*ns);
-  } else {
-    efld.resize(0);
-  }
 
-  bx.resize(ns);
-  by.resize(ns);
-  ax.resize(ns);
-  ay.resize(ns);
-  ex.resize(ns);
-  ey.resize(ns);
-  if (doCurrent) {
-    cu.resize(ns*nz);
-  } else {
-    cu.resize(ns);
+  can_change_diaghooks=false;
+  for(unsigned int k=0; k<diaghooks.size(); k++) {
+    diaghooks.at(k)->init(nz,ns);
   }
-  
-  bh.clear();
-  ph.clear();
-  if (bharm>1){
-    bh.resize(bharm-1);
-    ph.resize(bharm-1);
-    for (int i=0;i<(bharm-1);i++){
-      bh[i].resize(nz*ns);
-      ph[i].resize(nz*ns);
-    }
-  }
-  if (doEnergy){ 
-    tgavg.resize(nz);
-    tgsig.resize(nz);
-  } else {
-    tgavg.resize(0);
-    tgsig.resize(0);
-  }
-  if (doSpatial){
-    txavg.resize(nz);
-    txsig.resize(nz);
-    tyavg.resize(nz);
-    tysig.resize(nz);
-  } else {
-    txavg.resize(0);
-    txsig.resize(0);
-    tyavg.resize(0);
-    tysig.resize(0);
-  }
-  tbun.resize(nz);
 }
 
 // initialize the sorting routine
@@ -279,244 +240,12 @@ bool Beam::subharmonicConversion(int harmonic, bool resample)
 
 void Beam::diagnostics(bool output, double z)
 {
-
   if (!output) { return; }
 
-  double acc_cur,acc_g,acc_g2,acc_x,acc_x2,acc_y,acc_y2;
-  // complex<double> acc_b=(0,0);
-  acc_cur=0;
-  acc_g=0;
-  acc_g2=0;
-  acc_x=0;
-  acc_x2=0;
-  acc_y=0;
-  acc_y2=0;
+  // update diagnostics data in all registered diagnostics modules
+  beam_diag_do_diag(z);
 
-  zpos[idx]=z;
-
-  int ds=beam.size();
-  int ioff=idx*ds; 
-
-  for (int is=0; is < ds; is++){
-    double bgavg=0;
-    double bgsig=0;
-    double bxavg=0;
-    double bxsig=0;
-    double byavg=0;
-    double bysig=0;
-    double bpxavg=0;
-    double bpyavg=0;
-    double br=0;
-    double bi=0;
-    double bbavg=0;
-    double bbphi=0;
-
-    unsigned int nsize=beam.at(is).size();
-    for (int i=0;i < nsize;i++){
-      double xtmp=beam.at(is).at(i).x;
-      double ytmp=beam.at(is).at(i).y;
-      double pxtmp=beam.at(is).at(i).px;
-      double pytmp=beam.at(is).at(i).py;
-      double gtmp=beam.at(is).at(i).gamma;
-      double btmp=beam.at(is).at(i).theta;
-      bxavg +=xtmp;
-      byavg +=ytmp;
-      bpxavg+=pxtmp;
-      bpyavg+=pytmp;
-      bgavg +=gtmp;
-      bgsig +=gtmp*gtmp;
-      bxsig +=xtmp*xtmp;
-      bysig +=ytmp*ytmp;
-      br+=cos(btmp);
-      bi+=sin(btmp);
-    }
-    
-
-    double scl=1;
-    if (nsize>0){
-      scl=1./static_cast<double>(nsize);
-    }
-
-    bgavg*=scl;
-    bxavg*=scl;
-    byavg*=scl;
-    bgsig*=scl;
-    bxsig*=scl;
-    bysig*=scl;
-    bpxavg*=scl;
-    bpyavg*=scl;
- 
-    if (do_global_stat){
-      acc_cur+=current[is];
-      acc_g+= bgavg*current[is];
-      acc_g2+=bgsig*current[is];
-      acc_x+= bxavg*current[is];
-      acc_x2+=bxsig*current[is];
-      acc_y+= byavg*current[is];
-      acc_y2+=bysig*current[is];
-    }
-
-    bbavg=sqrt(bi*bi+br*br)*scl;
-    bbphi=atan2(bi,br);
-    bgsig=sqrt(fabs(bgsig-bgavg*bgavg));
-    bxsig=sqrt(fabs(bxsig-bxavg*bxavg));
-    bysig=sqrt(fabs(bysig-byavg*byavg));
-
-    if (doCurrent){
-      cu[ioff+is]=current[is];
-    }
-    if (doEnergy){
-      gavg[ioff+is]=bgavg;
-      gsig[ioff+is]=bgsig;
-    }
-    if (doSpatial){
-      xavg[ioff+is]=bxavg;
-      xsig[ioff+is]=bxsig;
-      yavg[ioff+is]=byavg;
-      ysig[ioff+is]=bysig;
-      pxavg[ioff+is]=bpxavg;
-      pyavg[ioff+is]=bpyavg;
-    }
-    bunch[ioff+is]=bbavg;
-    bphi[ioff+is]=bbphi;
-    if (doAux){
-       efld[ioff+is]=eloss[is];  
-    }
-    //    partcount[ioff+is]=nsize;
-
-    for (int ih=1; ih<bharm;ih++){   // calculate the harmonics of the bunching
-      br=0;
-      bi=0;
-      for (int i=0;i < nsize;i++){
-        double btmp=static_cast<double>(ih+1)*beam.at(is).at(i).theta;
-        br+=cos(btmp);
-        bi+=sin(btmp);
-      }
-      bh[ih-1][ioff+is]=sqrt(bi*bi+br*br)*scl;
-      ph[ih-1][ioff+is]=atan2(bi,br);
-    }
-  }
-
-
-  // accumulate all data fromt eh cores
-  double temp=0;
-  int size;      
-  if(do_global_stat) {
-      MPI_Comm_size(MPI_COMM_WORLD, &size);
-      if (size>1){
-	MPI_Allreduce(&acc_cur, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-	acc_cur=temp;
-	MPI_Allreduce(&acc_g, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-	acc_g=temp;
-	MPI_Allreduce(&acc_g2, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-	acc_g2=temp;
-	MPI_Allreduce(&acc_x, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-	acc_x=temp;
-	MPI_Allreduce(&acc_x2, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-	acc_x2=temp;
-	MPI_Allreduce(&acc_y, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-	acc_y=temp;
-	MPI_Allreduce(&acc_y2, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-	acc_y2=temp;
-      }
-      if (acc_cur==0){
-         acc_cur=1.; 
-      }
-      acc_g/= acc_cur;
-      acc_g2/=acc_cur;
-      acc_x/= acc_cur;
-      acc_x2/=acc_cur;
-      acc_y/= acc_cur;
-      acc_y2/=acc_cur;
-      acc_g2=sqrt(abs(acc_g2-acc_g*acc_g));
-      acc_x2=sqrt(abs(acc_x2-acc_x*acc_x));
-      acc_y2=sqrt(abs(acc_y2-acc_y*acc_y));
-      if (doEnergy){
-        tgavg[idx]=acc_g;
-	tgsig[idx]=acc_g2;
-      }
-      if (doSpatial){
-        txavg[idx]=acc_x;
-        txsig[idx]=acc_x2;
-        tyavg[idx]=acc_y;
-        tysig[idx]=acc_y2;
-     }
-  }
-
+  // Beam diagnostics complete: increment index into arrays holding the diagnostic data
   idx++;
-}
-
-
-void Beam::diagnosticsStart()
-{
-  double gx,gy,gammax,gammay;
-  double x1,y1,x2,y2,px1,py1,px2,py2,g1,xpx,ypy;
-
-  int ds=beam.size();
-
-
-  for (int is=0; is<ds;is++){
-    if (!doCurrent){
-      cu[is]=current[is];
-    }
-    x1=0;
-    x2=0;
-    px1=0;
-    px2=0;
-    y1=0;
-    y2=0;
-    py1=0;
-    py2=0;
-    xpx=0;
-    ypy=0;
-    g1=0;
-    unsigned int nsize=beam.at(is).size();
-    for (int i=0;i < nsize;i++){
-      double xtmp=beam.at(is).at(i).x;
-      double ytmp=beam.at(is).at(i).y;
-      double pxtmp=beam.at(is).at(i).px;
-      double pytmp=beam.at(is).at(i).py;
-      double gtmp=beam.at(is).at(i).gamma;
-      x1+=xtmp;
-      y1+=ytmp;
-      px1+=pxtmp;
-      py1+=pytmp;
-      g1+=gtmp; 
-      x2+=xtmp*xtmp;
-      y2+=ytmp*ytmp;
-      px2+=pxtmp*pxtmp;
-      py2+=pytmp*pytmp;
-      xpx+=xtmp*pxtmp;
-      ypy+=ytmp*pytmp;
-    }
-    double norm=1.;
-    if (nsize>0){ norm=1./static_cast<double>(nsize);}
-    x1*=norm;
-    x2*=norm;
-    y1*=norm;
-    y2*=norm;
-    px1*=norm;
-    px2*=norm;
-    py1*=norm;
-    py2*=norm;
-    g1*=norm;
-    xpx*=norm;
-    ypy*=norm;
-    
-    // because genesis works with momenta and not divergence, the emittance does not need energy
-    ex[is]=sqrt(fabs((x2-x1*x1)*(px2-px1*px1)-(xpx-x1*px1)*(xpx-x1*px1)));
-    ey[is]=sqrt(fabs((y2-y1*y1)*(py2-py1*py1)-(ypy-y1*py1)*(ypy-y1*py1)));
-    bx[is]=(x2-x1*x1)/ex[is]*g1;
-    by[is]=(y2-y1*y1)/ey[is]*g1;
-    ax[is]=-(xpx-x1*px1)/ex[is];
-    ay[is]=-(ypy-y1*py1)/ey[is];
-     
-    gx=(1+ax[is]*ax[is])/bx[is];
-    gy=(1+ay[is]*ay[is])/by[is];
-
-  }
-
-
-  return;
 }
 

--- a/src/Core/BeamDiag.cpp
+++ b/src/Core/BeamDiag.cpp
@@ -1,0 +1,22 @@
+#include "BeamDiag.h"
+/*
+ * See the header file for a list of functions that have
+ * to be implemented in your derived diagnostics class.
+ */
+
+
+BeamDiag::BeamDiag() {
+}
+
+BeamDiag::~BeamDiag() {
+}
+
+std::string BeamDiag::to_str(void) const {
+	return "BeamDiag object (consider implementing a 'to_str' member function)";
+}
+
+// This operator is not member of the class, see:
+// Item 24 in S. Meyers: Effective C++, 3rd Ed., Pearson Education, 2005
+std::ostream& operator<< (std::ostream& os, const BeamDiag& bd) {
+	return (os << bd.to_str());
+}

--- a/src/Core/BeamDiag_Demo.cpp
+++ b/src/Core/BeamDiag_Demo.cpp
@@ -1,0 +1,87 @@
+#include <mpi.h>
+#include <hdf5.h>
+#include <math.h>
+#include <iostream>
+#include <sstream>
+#include "BeamDiag_Demo.h"
+
+BeamDiag_Demo::BeamDiag_Demo() {
+	MPI_Comm_rank(MPI_COMM_WORLD, &my_rank_);
+
+	// force call to class-specific function 'init' before 'do_diag'
+	is_initialized_=false;
+	// force call to class-specific function 'configure' before 'do_diag'
+	is_configured_=false;
+
+	// these are overwritten before the actual tracking begins
+	param_x_ = 0;
+
+	verbose_ = false;
+
+	ns_=0;
+	idx_=0;
+}
+
+BeamDiag_Demo::~BeamDiag_Demo() {
+
+}
+
+std::string BeamDiag_Demo::to_str(void) const {
+	stringstream ss;
+	ss << "BeamDiag_Demo(verbose=" << verbose_ << ")";
+	return(ss.str());
+}
+
+void BeamDiag_Demo::init(int nz, int ns) {
+	demodiag_data_.resize(nz*ns);
+	ns_ = ns;
+	idx_ = 0;
+	is_initialized_=true;
+}
+
+/* configuration functions */
+void BeamDiag_Demo::config(unsigned long long param_x_in) {
+	param_x_ = param_x_in;
+
+	is_configured_=true;
+}
+void BeamDiag_Demo::set_verbose(bool v_in) {
+	verbose_ = v_in;
+}
+
+/* Called when the electron beam is diagnosed, typically after every integration step */
+void BeamDiag_Demo::do_diag(const Beam *beam, double z) {
+	int ioff=idx_*ns_;
+
+	if((is_configured_==false) || (is_initialized_==false)){
+		cout << "Error (BeamDiag_Demo): do_diag called, but class instance is not configured" << endl;
+	}
+
+	if(verbose_ && (0==my_rank_)) {
+		cout << "--> BeamDiag_Demo::do_diag called" << endl;
+	}
+
+	/* loop over local slices */	
+	for (int is=0; is<ns_; is++) {
+		// obtain number of particles in this slice
+		unsigned int npart = beam->beam.at(is).size();
+
+		/* here you could process the particles */
+
+		demodiag_data_.at(ioff+is) = npart+param_x_;
+	}
+
+	idx_++;
+}
+
+/* This function is called when the .out.h5 file is written */
+void BeamDiag_Demo::output(hid_t parentobj) {
+	if(verbose_ && (0==my_rank_)) {
+		cout << "--> BeamDiag_Demo::output called" << endl;
+	}
+
+	// Configure HDF5 write using members inherited from HDF5Base class (FIXME)
+	ds = ns_;
+	s0 = my_rank_*ns_;
+	writeBufferULL(parentobj, "diag_demo", " ", &demodiag_data_);
+}

--- a/src/Core/BeamDiag_HDF5helper.cpp
+++ b/src/Core/BeamDiag_HDF5helper.cpp
@@ -1,0 +1,16 @@
+#include "BeamDiag_HDF5helper.h"
+#include "HDF5base.h"
+
+BeamDiag_HDF5Helper::BeamDiag_HDF5Helper() {
+	/* avoid random garbage values in these most important variables controlling HDF5 I/O */
+	s0 = 1;
+	ds = 1;
+}
+BeamDiag_HDF5Helper::~BeamDiag_HDF5Helper() {}
+
+void BeamDiag_HDF5Helper::set_s0(int s0_in) {
+	s0 = s0_in;
+}
+void BeamDiag_HDF5Helper::set_ds(int ds_in) {
+	ds = ds_in;
+}

--- a/src/Core/BeamDiag_Std.cpp
+++ b/src/Core/BeamDiag_Std.cpp
@@ -1,0 +1,456 @@
+#include <mpi.h>
+#include <hdf5.h>
+#include <math.h>
+#include <iostream>
+#include <sstream>
+#include "BeamDiag_Std.h"
+#include "BeamDiag_HDF5helper.h"
+
+BeamDiag_Std::BeamDiag_Std() {
+	MPI_Comm_rank(MPI_COMM_WORLD, &my_rank_);
+
+	// force call to class-specific function 'init' before 'do_diag'
+	is_initialized_=false;
+	// force call to class-specific function 'configure' before 'do_diag'
+	is_configured_=true; // <-- no required configuration variables at the moment
+
+	bharm=1;
+
+	/* defaults as previously in Beam::Beam */
+	do_global_stat=false;
+	doCurrent=false;
+	doSpatial=true;
+	doEnergy=true;
+	doAux=true;
+
+	verbose_ = false;
+
+	ns_=0;
+	idx_=0;
+}
+
+BeamDiag_Std::~BeamDiag_Std() {
+
+}
+
+std::string BeamDiag_Std::to_str(void) const {
+	stringstream ss;
+	ss << "BeamDiag_Std";
+	return(ss.str());
+}
+
+void BeamDiag_Std::init(int nz, int ns) {
+	ns_ = ns;
+	idx_ = 0;
+	is_initialized_=true;
+
+  /* code from Beam::initDiagnostics */
+  zpos.resize(nz);
+  if (doSpatial){
+    xavg.resize(nz*ns);
+    xsig.resize(nz*ns);
+    yavg.resize(nz*ns);
+    ysig.resize(nz*ns);
+    pxavg.resize(nz*ns);
+    pyavg.resize(nz*ns);
+  } else {
+    xavg.resize(0);
+    xsig.resize(0);
+    yavg.resize(0);
+    ysig.resize(0);
+    pxavg.resize(0);
+    pyavg.resize(0);
+  }
+  if (doEnergy) {
+    gavg.resize(nz*ns);
+    gsig.resize(nz*ns);
+  } else {
+    gavg.resize(0);
+    gsig.resize(0);
+  }
+  bunch.resize(nz*ns); 
+  bphi.resize(nz*ns);
+  if (doAux){
+    efld.resize(nz*ns);
+  } else {
+    efld.resize(0);
+  }
+
+  bx.resize(ns);
+  by.resize(ns);
+  ax.resize(ns);
+  ay.resize(ns);
+  ex.resize(ns);
+  ey.resize(ns);
+  if (doCurrent) {
+    cu.resize(ns*nz);
+  } else {
+    cu.resize(ns);
+  }
+  
+  bh.clear();
+  ph.clear();
+  if (bharm>1){
+    bh.resize(bharm-1);
+    ph.resize(bharm-1);
+    for (int i=0;i<(bharm-1);i++){
+      bh[i].resize(nz*ns);
+      ph[i].resize(nz*ns);
+    }
+  }
+  if (doEnergy){ 
+    tgavg.resize(nz);
+    tgsig.resize(nz);
+  } else {
+    tgavg.resize(0);
+    tgsig.resize(0);
+  }
+  if (doSpatial){
+    txavg.resize(nz);
+    txsig.resize(nz);
+    tyavg.resize(nz);
+    tysig.resize(nz);
+  } else {
+    txavg.resize(0);
+    txsig.resize(0);
+    tyavg.resize(0);
+    tysig.resize(0);
+  }
+  tbun.resize(nz);
+}
+
+/* configuration functions */
+void BeamDiag_Std::setBunchingHarmonicOutput(int harm_in){bharm=harm_in;}
+int BeamDiag_Std::getBunchingHarmonics(){return bharm;}
+void BeamDiag_Std::set_global_stat(bool in){do_global_stat=in;}
+bool BeamDiag_Std::get_global_stat(void){return(do_global_stat);}
+void BeamDiag_Std::setOutput(bool noCurrent_in, bool noEnergy_in, bool noSpatial_in, bool noAux_in) {
+  doCurrent = !noCurrent_in;
+  doSpatial = !noSpatial_in;
+  doEnergy = !noEnergy_in;
+  doAux = !noAux_in;
+}
+
+/* Called when the electron beam is diagnosed, typically after every integration step */
+void BeamDiag_Std::do_diag(const Beam *beam, double z) {
+	int ioff=idx_*ns_;
+
+	if((is_configured_==false) || (is_initialized_==false)){
+		cout << "Error (BeamDiag_Std): do_diag called, but class instance is not configured" << endl;
+	}
+
+	if(verbose_ && (0==my_rank_)) {
+		cout << "--> BeamDiag_Std::do_diag called" << endl;
+	}
+
+	/* FIXME */
+	if(beam->beam.size() != ns_) {
+		cout << "*** error: assertion ***" << endl;
+	}
+
+  /* Code from Beam::diagnostics */
+  double acc_cur,acc_g,acc_g2,acc_x,acc_x2,acc_y,acc_y2;
+  complex<double> acc_b=(0,0);
+  acc_cur=0;
+  acc_g=0;
+  acc_g2=0;
+  acc_x=0;
+  acc_x2=0;
+  acc_y=0;
+  acc_y2=0;
+
+  zpos[idx_]=z;
+
+  for (int is=0; is < ns_; is++){
+    double bgavg=0;
+    double bgsig=0;
+    double bxavg=0;
+    double bxsig=0;
+    double byavg=0;
+    double bysig=0;
+    double bpxavg=0;
+    double bpyavg=0;
+    double br=0;
+    double bi=0;
+    double bbavg=0;
+    double bbphi=0;
+
+    unsigned int nsize=beam->beam.at(is).size();
+    for (int i=0;i < nsize;i++){
+      double xtmp=beam->beam.at(is).at(i).x;
+      double ytmp=beam->beam.at(is).at(i).y;
+      double pxtmp=beam->beam.at(is).at(i).px;
+      double pytmp=beam->beam.at(is).at(i).py;
+      double gtmp=beam->beam.at(is).at(i).gamma;
+      double btmp=beam->beam.at(is).at(i).theta;
+      bxavg +=xtmp;
+      byavg +=ytmp;
+      bpxavg+=pxtmp;
+      bpyavg+=pytmp;
+      bgavg +=gtmp;
+      bgsig +=gtmp*gtmp;
+      bxsig +=xtmp*xtmp;
+      bysig +=ytmp*ytmp;
+      br+=cos(btmp);
+      bi+=sin(btmp);
+    }
+    
+
+    double scl=1;
+    if (nsize>0){
+      scl=1./static_cast<double>(nsize);
+    }
+
+    bgavg*=scl;
+    bxavg*=scl;
+    byavg*=scl;
+    bgsig*=scl;
+    bxsig*=scl;
+    bysig*=scl;
+    bpxavg*=scl;
+    bpyavg*=scl;
+ 
+    if (do_global_stat){
+      acc_cur+=beam->current[is];
+      acc_g+= bgavg*beam->current[is];
+      acc_g2+=bgsig*beam->current[is];
+      acc_x+= bxavg*beam->current[is];
+      acc_x2+=bxsig*beam->current[is];
+      acc_y+= byavg*beam->current[is];
+      acc_y2+=bysig*beam->current[is];
+    }
+
+    bbavg=sqrt(bi*bi+br*br)*scl;
+    bbphi=atan2(bi,br);
+    bgsig=sqrt(fabs(bgsig-bgavg*bgavg));
+    bxsig=sqrt(fabs(bxsig-bxavg*bxavg));
+    bysig=sqrt(fabs(bysig-byavg*byavg));
+
+    if (doCurrent){
+      cu[ioff+is]=beam->current[is];
+    }
+    if (doEnergy){
+      gavg[ioff+is]=bgavg;
+      gsig[ioff+is]=bgsig;
+    }
+    if (doSpatial){
+      xavg[ioff+is]=bxavg;
+      xsig[ioff+is]=bxsig;
+      yavg[ioff+is]=byavg;
+      ysig[ioff+is]=bysig;
+      pxavg[ioff+is]=bpxavg;
+      pyavg[ioff+is]=bpyavg;
+    }
+    bunch[ioff+is]=bbavg;
+    bphi[ioff+is]=bbphi;
+    if (doAux){
+       efld[ioff+is]=beam->eloss[is];  
+    }
+    //    partcount[ioff+is]=nsize;
+
+    for (int ih=1; ih<bharm;ih++){   // calculate the harmonics of the bunching
+      br=0;
+      bi=0;
+      for (int i=0;i < nsize;i++){
+        double btmp=static_cast<double>(ih+1)*beam->beam.at(is).at(i).theta;
+        br+=cos(btmp);
+        bi+=sin(btmp);
+      }
+      bh[ih-1][ioff+is]=sqrt(bi*bi+br*br)*scl;
+      ph[ih-1][ioff+is]=atan2(bi,br);
+    }
+  }
+
+
+  // accumulate all data from the cores
+  double temp=0;
+  int size;      
+  if(do_global_stat) {
+      MPI_Comm_size(MPI_COMM_WORLD, &size);
+      if (size>1){
+	MPI_Allreduce(&acc_cur, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+	acc_cur=temp;
+	MPI_Allreduce(&acc_g, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+	acc_g=temp;
+	MPI_Allreduce(&acc_g2, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+	acc_g2=temp;
+	MPI_Allreduce(&acc_x, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+	acc_x=temp;
+	MPI_Allreduce(&acc_x2, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+	acc_x2=temp;
+	MPI_Allreduce(&acc_y, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+	acc_y=temp;
+	MPI_Allreduce(&acc_y2, &temp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+	acc_y2=temp;
+      }
+      if (acc_cur==0){
+         acc_cur=1.; 
+      }
+      acc_g/= acc_cur;
+      acc_g2/=acc_cur;
+      acc_x/= acc_cur;
+      acc_x2/=acc_cur;
+      acc_y/= acc_cur;
+      acc_y2/=acc_cur;
+      acc_g2=sqrt(abs(acc_g2-acc_g*acc_g));
+      acc_x2=sqrt(abs(acc_x2-acc_x*acc_x));
+      acc_y2=sqrt(abs(acc_y2-acc_y*acc_y));
+      if (doEnergy){
+        tgavg[idx_]=acc_g;
+	tgsig[idx_]=acc_g2;
+      }
+      if (doSpatial){
+        txavg[idx_]=acc_x;
+        txsig[idx_]=acc_x2;
+        tyavg[idx_]=acc_y;
+        tysig[idx_]=acc_y2;
+     }
+  }
+
+	idx_++;
+}
+void BeamDiag_Std::do_initial_diag(const Beam *beam)
+{
+  // double gx,gy,gammax,gammay;
+  double x1,y1,x2,y2,px1,py1,px2,py2,g1,xpx,ypy;
+
+  int ds=beam->beam.size();
+
+	if((is_configured_==false) || (is_initialized_==false)){
+		cout << "Error (BeamDiag_Std): do_initial_diag called, but class instance is not configured" << endl;
+	}
+
+	if(verbose_ && (0==my_rank_)) {
+		cout << "--> BeamDiag_Std::do_initial_diag called" << endl;
+	}
+
+  for (int is=0; is<ds;is++){
+    if (!doCurrent){
+      cu[is]=beam->current[is];
+    }
+    x1=0;
+    x2=0;
+    px1=0;
+    px2=0;
+    y1=0;
+    y2=0;
+    py1=0;
+    py2=0;
+    xpx=0;
+    ypy=0;
+    g1=0;
+    unsigned int nsize=beam->beam.at(is).size();
+    for (int i=0;i < nsize;i++){
+      double xtmp=beam->beam.at(is).at(i).x;
+      double ytmp=beam->beam.at(is).at(i).y;
+      double pxtmp=beam->beam.at(is).at(i).px;
+      double pytmp=beam->beam.at(is).at(i).py;
+      double gtmp=beam->beam.at(is).at(i).gamma;
+      x1+=xtmp;
+      y1+=ytmp;
+      px1+=pxtmp;
+      py1+=pytmp;
+      g1+=gtmp; 
+      x2+=xtmp*xtmp;
+      y2+=ytmp*ytmp;
+      px2+=pxtmp*pxtmp;
+      py2+=pytmp*pytmp;
+      xpx+=xtmp*pxtmp;
+      ypy+=ytmp*pytmp;
+    }
+    double norm=1.;
+    if (nsize>0){ norm=1./static_cast<double>(nsize);}
+    x1*=norm;
+    x2*=norm;
+    y1*=norm;
+    y2*=norm;
+    px1*=norm;
+    px2*=norm;
+    py1*=norm;
+    py2*=norm;
+    g1*=norm;
+    xpx*=norm;
+    ypy*=norm;
+    
+    // because genesis works with momenta and not divergence, the emittance does not need energy
+    ex[is]=sqrt(fabs((x2-x1*x1)*(px2-px1*px1)-(xpx-x1*px1)*(xpx-x1*px1)));
+    ey[is]=sqrt(fabs((y2-y1*y1)*(py2-py1*py1)-(ypy-y1*py1)*(ypy-y1*py1)));
+    bx[is]=(x2-x1*x1)/ex[is]*g1;
+    by[is]=(y2-y1*y1)/ey[is]*g1;
+    ax[is]=-(xpx-x1*px1)/ex[is];
+    ay[is]=-(ypy-y1*py1)/ey[is];
+     
+    // gx=(1+ax[is]*ax[is])/bx[is];
+    // gy=(1+ay[is]*ay[is])/by[is];
+
+  }
+
+  return;
+}
+
+
+/* This function is called when the .out.h5 file is written */
+void BeamDiag_Std::output(hid_t parentobj) {
+	if(verbose_ && (0==my_rank_)) {
+		cout << "--> BeamDiag_Std::output called" << endl;
+	}
+
+  hid_t gid=parentobj;
+  hid_t gidsub;
+  BeamDiag_HDF5Helper hh;
+
+  hh.set_ds(ns_);
+  hh.set_s0(my_rank_*ns_);
+
+  /* Code from Output::writeBeamBuffer */
+  // step 2 - write individual datasets
+  if (doEnergy){
+    hh.writeBuffer(gid, "energy"," ",&gavg);
+    hh.writeBuffer(gid, "energyspread"," ", &gsig);
+  }
+  if (doSpatial){
+    hh.writeBuffer(gid, "xposition","m",&xavg);
+    hh.writeBuffer(gid, "yposition","m",&yavg);
+    hh.writeBuffer(gid, "pxposition","rad", &pxavg);
+    hh.writeBuffer(gid, "pyposition","rad", &pyavg);
+    hh.writeBuffer(gid, "xsize","m", &xsig);
+    hh.writeBuffer(gid, "ysize","m", &ysig);
+  }
+  hh.writeBuffer(gid, "bunching"," ",&bunch);
+  hh.writeBuffer(gid, "bunchingphase","rad", &bphi);
+  if (doAux){
+    hh.writeBuffer(gid, "efield","eV/m", &efld);
+  }
+  
+  hh.writeBuffer(gid, "betax","m",&bx);
+  hh.writeBuffer(gid, "betay","m",&by);
+  hh.writeBuffer(gid, "alphax","rad",&ax);
+  hh.writeBuffer(gid, "alphay","rad",&ay);
+  hh.writeBuffer(gid, "emitx","m",&ex);
+  hh.writeBuffer(gid, "emity","m",&ey);
+  hh.writeBuffer(gid, "current","A",&cu);
+
+  // int bh=beam->getBunchingHarmonics();
+  char bgroup[20];
+  for (int i=1; i<bharm;i++){
+    sprintf(bgroup,"bunching%d",(i+1));
+    hh.writeBuffer(gid, bgroup, " ",  &bh[i-1]);
+    sprintf(bgroup,"bunchingphase%d",(i+1));
+    hh.writeBuffer(gid, bgroup,"rad",  &ph[i-1]);
+  }
+
+  if(do_global_stat) {
+    gidsub=H5Gcreate(gid,"Global",H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);
+    if (doEnergy){
+      hh.writeSingleNode(gidsub,"energy"," ", &tgavg);
+      hh.writeSingleNode(gidsub,"energyspread"," ", &tgsig);
+    }
+    if (doSpatial){
+      hh.writeSingleNode(gidsub,"xposition","m", &txavg);
+      hh.writeSingleNode(gidsub,"xsize","m", &txsig);
+      hh.writeSingleNode(gidsub,"yposition","m", &tyavg);
+      hh.writeSingleNode(gidsub,"ysize","m", &tysig);
+    }
+    H5Gclose(gidsub);  
+  }
+}

--- a/src/Core/Control.cpp
+++ b/src/Core/Control.cpp
@@ -3,7 +3,7 @@
 #include "Control.h"
 #include "writeFieldHDF5.h"
 #include "writeBeamHDF5.h"
-
+#include "BeamDiag_Std.h"
 
 
 
@@ -142,7 +142,7 @@ bool Control::init(int inrank, int insize, const char *file, Beam *beam, vector<
 
   beam->initDiagnostics(und->outlength());
   beam->diagnostics(true,0);
-  beam->diagnosticsStart();
+  beam->bd_std->do_initial_diag(beam); // beam->diagnosticsStart();
   for (unsigned int i=0; i<field->size();i++){
       field->at(i)->initDiagnostics(und->outlength());
       field->at(i)->diagnostics(true);  // initial values


### PR DESCRIPTION
Code for modular electron beam diagnostics.

The existing electron beam diagnostics code, the member variables holding the data, and the corresponding output code were collected from various places into class 'BeamDiag_Std'.

Additional electron beam diagnostics code can be added (and configured, if needed) in function 'Track::init'. Then the diagnostics information is updated after every simulation step and finally the collected information is written to the .out.h5 file. (Note that there is no need to introduce additional code/member variables in classes 'Beam' or 'Output', as the code of the additional electron beam diagnostics is contained in a class that is registered in Track::init.)

For illustration there is the example ebeam diagnostics class 'BeamDiag_Demo' that can be enabled by compiling with the preprocessor macro DO_BEAMDIAG_DEMO set. It writes an additional object into the .out.h5 file, containing "particle counts + a configurable offset".

See also manual/modular_beam_diag.txt.