### PR TITLE
semaphore files + new command line parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ Version 4.5.1 has been released. Part of it is this Change Log file, which will 
 - Command line arguments are now overwriting the correpsonding input the main input file. Supported are the output file root name, the lattice file, the beam line and the seed for the shot noise power.
 - The compilation is changed to CMAKE, which allows for some configuration before compilation. It automatically searches for the required libraries and no manual configuration of the Makefile is needed any longer. 
 - 20220218: New command line parser
+- 20220218: Added support for semaphore file. If requested, this file is written at the end of a successful simulation run.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,6 @@ Version 4.5.1 has been released. Part of it is this Change Log file, which will 
 - Moved the calculation for the output file from the Beam and Field class to the class Diagnostic.cpp. This class interacts with the class  in Output.cpp so that the output class does not need to know the name of the field to be written. This informationis provided by the new class in Diagnostic.cpp. That way it gets easier to add additional output, where only on location needs to be changed (namely the derived classes in DiagnostUser.cpp)
 - Command line arguments are now overwriting the correpsonding input the main input file. Supported are the output file root name, the lattice file, the beam line and the seed for the shot noise power.
 - The compilation is changed to CMAKE, which allows for some configuration before compilation. It automatically searches for the required libraries and no manual configuration of the Makefile is needed any longer. 
-
+- 20220218: New command line parser
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ Version 4.5.1 has been released. Part of it is this Change Log file, which will 
 - The compilation is changed to CMAKE, which allows for some configuration before compilation. It automatically searches for the required libraries and no manual configuration of the Makefile is needed any longer. 
 - 20220218: New command line parser
 - 20220218: Added support for semaphore file. If requested, this file is written at the end of a successful simulation run.
+- 20220218: Exit code of GENESIS binary now depends on status (0 for success, 1 in case of error)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
 # OpenMPI: preprocessor macro to disable C++ interface (then we don't have to link libmpi_cxx)
-#add_compile_definitions(OMPI_SKIP_MPICXX)
+add_compile_definitions(OMPI_SKIP_MPICXX)
 
 list(APPEND CMAKE_PREFIX_PATH $ENV{FFTW_ROOT})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ add_library(genesis13 STATIC
         src/Util/RandomU.cpp
         src/Util/Sorting.cpp
         src/Util/StringProcessing.cpp
+        src/Util/SemaFile.cpp
         src/Lattice/AlterLattice.cpp
         src/Lattice/Lattice.cpp
         src/Lattice/LatticeElements.cpp

--- a/MANUAL_MAIN.md
+++ b/MANUAL_MAIN.md
@@ -113,6 +113,8 @@ user want to change some parameter the namelist `altersetup` should be used.
     true and sorting events the current profile might change. Example are ESASE/HGHG
     schemes. By setting the flag to false the current profile is written out at each output
     step similar to radiation power and bunching profile
+- `write_semaphore_file` (*bool, false*): If true, an empty file is generated as the simulation is completed. The default file name is derived from `rootname` and has the extension `.sema`. No file is written if the simulation aborts (examples are errors while parsing the input file or errors while executing commands), or if the simulation crashes (for example because of out-of-memory condition).
+- `semaphore_file_name` (*string,< rootname.sema >*): Adjust name of semaphore file written as simulation is completed. Assigning this parameter automatically sets `write_semaphore_file=true`, overriding the value of `write_semaphore_file` in the input file. This parameter can also be specified using the `--semaphore-file` command line option.
 
 <a name="altersetup">**altersetup**</a>
 

--- a/include/Parser.h
+++ b/include/Parser.h
@@ -24,12 +24,15 @@ class Parser : public StringProcessing {
    bool open(string, int);
    bool parse(string *,map<string,string> *);
 
+   bool fail(void);
+
  private:
 
    int rank;
    istringstream input;
    bool fillMap(string *,map<string,string> *);
 
+   bool is_parse_error;
 };
 
 

--- a/include/SemaFile.h
+++ b/include/SemaFile.h
@@ -1,0 +1,17 @@
+#ifndef __G4_SEMAFILE_H
+#define __G4_SEMAFILE_H
+
+#include <string>
+
+class SemaFile {
+public:
+	SemaFile();
+	~SemaFile();
+
+	void remove(std::string);
+	void put(std::string);
+
+private:
+	int my_rank_;
+};
+#endif // __G4_SEMAFILE_H

--- a/include/Setup.h
+++ b/include/Setup.h
@@ -41,6 +41,10 @@ class Setup: public StringProcessing{
    bool   outputEnergy();
    bool   outputAux();
    bool   outputFieldDump();
+   bool   getSemaEn();
+   void   setSemaFN(string);
+   bool   getSemaFN(string *);
+
    int    getNpart();
    int    getNbins();
    int    getSeed();
@@ -74,6 +78,9 @@ class Setup: public StringProcessing{
    int beam_write_slices_from, beam_write_slices_to, beam_write_slices_inc;
 
    int seed, rank,npart,nbins,runcount;
+
+   bool sema_file_enabled;
+   string sema_file_name; // user-defined name of semaphore file, if empty: file name will be derived in function getSemaFN
 };
 
 inline string Setup::getLattice(){return lattice;}
@@ -119,4 +126,6 @@ inline void   Setup::BWF_set_inc(int in)
 	}
 	beam_write_slices_inc=in;
 }
+
+inline bool   Setup::getSemaEn() { return sema_file_enabled; }
 #endif

--- a/include/genesis.h
+++ b/include/genesis.h
@@ -9,7 +9,6 @@
 
 using namespace std;
 
+int genmain(string, map<string,string> &,bool);
 
-
-double genmain(string, map<string,string> &,bool);
 #endif

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -84,9 +84,10 @@ double genmain (string mainstring, map<string,string> &comarg, bool split) {
 	//	event.push_back("start");
 	//	evtime.push_back(0);
 
-	if (rank==0){         // the output of version and build has been moved to the wrapper mainwrap.cpp
-    	  cout << "Starting Time: " << ctime(&timer)<< endl;
-          cout << "MPI-Comm Size: " << size << " nodes" << endl << endl;
+    if (rank==0){         // the output of version and build has been moved to the wrapper mainwrap.cpp
+        time(&timer);
+        cout << "Starting Time: " << ctime(&timer)<< endl;
+        cout << "MPI-Comm Size: " << size << " nodes" << endl << endl;
     }
 
     //---------------------------------------------------------

--- a/src/Main/Parser.cpp
+++ b/src/Main/Parser.cpp
@@ -2,15 +2,20 @@
 
 Parser::Parser()
 {
+  is_parse_error=false;
 }
 
 Parser::~Parser()
 {
 }
 
+bool Parser::fail(void)
+{
+  return (is_parse_error);
+}
+
 bool Parser::open(string file, int inrank)
 {
-
   string instring;
   ostringstream os;
   fstream fin;
@@ -27,14 +32,12 @@ bool Parser::open(string file, int inrank)
   fin.close();
   input.str(os.str());
   return true;
-
 }
 
 
 
 bool Parser::parse(string *element, map<string,string> *argument)
 {
-
   string instring, list;
   bool accumulate=false;
   
@@ -48,7 +51,8 @@ bool Parser::parse(string *element, map<string,string> *argument)
     // check for terminating element and then return
     if ((instring.compare("&end")==0)|| (instring.compare("&END")==0) || (instring.compare("&End")==0)){
       if (!accumulate){
-        if (rank==0){cout << "*** Error: Termination string outside element definition in input file" << endl;}    
+        if (rank==0){cout << "*** Error: Termination string outside element definition in input file" << endl;}
+        is_parse_error=true;
 	return false;
       }
       return this->fillMap(&list,argument);
@@ -58,6 +62,7 @@ bool Parser::parse(string *element, map<string,string> *argument)
     if (!instring.compare(0,1,"&")){
       if (accumulate){
         if (rank==0) {cout << "*** Error: Nested elements in main input file" << endl;}
+        is_parse_error=true;
 	return false;
       }
       accumulate=true;
@@ -66,7 +71,6 @@ bool Parser::parse(string *element, map<string,string> *argument)
       }
       *element=instring;   
       continue;
-
     }
 
     // add content if in element
@@ -77,7 +81,6 @@ bool Parser::parse(string *element, map<string,string> *argument)
   }
   
   return false;
-
 }
 
 bool Parser::fillMap(string *list,map<string,string> *map){
@@ -97,6 +100,7 @@ bool Parser::fillMap(string *list,map<string,string> *map){
        tpos=val.find_first_of("=");
        if (tpos ==string::npos){
          if (rank==0){ cout << "*** Error: Invalid format " << val << " in input file" << endl;}
+         is_parse_error=true;
          return false;
        } else{
          key=val.substr(0,tpos);
@@ -107,6 +111,7 @@ bool Parser::fillMap(string *list,map<string,string> *map){
        }
      }
   }
-  
+
+  is_parse_error=false; 
   return true;
 }

--- a/src/Main/Parser.cpp
+++ b/src/Main/Parser.cpp
@@ -79,6 +79,13 @@ bool Parser::parse(string *element, map<string,string> *argument)
        list.append(";");
     }
   }
+
+
+  if(accumulate) {
+    // Currently accumulating parameters of namelist, arriving here before reaching &end is considered an error
+    if (rank==0){cout << "*** Error: Reached end of input file while parsing namelist '" << *element << "'" << endl;}
+    is_parse_error=true;
+  }
   
   return false;
 }

--- a/src/Main/Setup.cpp
+++ b/src/Main/Setup.cpp
@@ -35,6 +35,8 @@ Setup::Setup()
 
   // count of runs in conjunction of calls of altersetup
   runcount = 0;
+
+  sema_file_enabled=false;
 }
 
 Setup::~Setup(){}
@@ -63,6 +65,8 @@ void Setup::usage(){
   cout << " bool exclude_aux_output = false" << endl;
   cout << " bool exclude_current_output = true" << endl;
   cout << " bool exclude_field_dump = false" << endl;
+  cout << " bool write_semaphore_file = false" << endl;
+  cout << " string semaphore_file_name = <derived from 'rootname'>" << endl;
   cout << "&end" << endl << endl;
   return;
 }
@@ -93,6 +97,13 @@ bool Setup::init(int inrank, map<string,string> *arg, Lattice *lat, FilterDiagno
   if (arg->find("exclude_aux_output")!=end)       {exclude_aux_output      = atob(arg->at("exclude_aux_output"));       arg->erase(arg->find("exclude_aux_output"));}
   if (arg->find("exclude_current_output")!=end)   {exclude_current_output  = atob(arg->at("exclude_current_output"));   arg->erase(arg->find("exclude_current_output"));}
   if (arg->find("exclude_field_dump")!=end)   {exclude_field_dump  = atob(arg->at("exclude_field_dump"));   arg->erase(arg->find("exclude_field_dump"));}
+  if (arg->find("write_semaphore_file")!=end)   {sema_file_enabled  = atob(arg->at("write_semaphore_file"));   arg->erase(arg->find("write_semaphore_file"));}
+  if (arg->find("semaphore_file_name")!=end) {
+    // Providing a file name for the semaphore file always switches it on, overriding 'write_semaphore_file' flag.
+    // This allows to switch on semaphore functionality just by specifying corresponding command line argument -- no modification of G4 input file needed.
+    sema_file_enabled = true;
+    setSemaFN(arg->at("semaphore_file_name")); arg->erase(arg->find("semaphore_file_name"));
+  }
 
   // same code also in AlterSetup.cpp
   if (arg->find("beam_write_slices_from")!=end) {
@@ -161,4 +172,26 @@ void Setup::BWF_load_defaults()
   beam_write_slices_from=-1;
   beam_write_slices_to=-1;
   beam_write_slices_inc=1;
+}
+
+
+
+
+/* returns true if filename for semaphore file was generated */
+bool Setup::getSemaFN(string *fnout) {
+	// user-defined filename overrides the logic to derive from rootname
+	if(! sema_file_name.empty()) {
+		*fnout = sema_file_name;
+		return(true);
+	}
+
+	if(rootname.empty()) {
+		return(false);
+	}
+	*fnout = rootname;
+	*fnout += ".sema";
+	return(true);
+}
+void Setup::setSemaFN(string fn_in) {
+	sema_file_name = fn_in;
 }

--- a/src/Main/mainwrap.cpp
+++ b/src/Main/mainwrap.cpp
@@ -72,8 +72,9 @@ int main (int argc, char *argv[])
 		{"lattice", 	required_argument,	NULL, 'l'},
 		{"beamline",	required_argument,	NULL, 'b'},
 		{"seed",	required_argument,	NULL, 's'},
+		{"semaphore-file", required_argument,	NULL, 'S'},
 		{"help",	no_argument,		NULL, 'h'},
-		{NULL, 0, NULL, 0}
+		{NULL, 0, NULL, 0}	/* marks end of list => do not remove */
 	};
 
 	// Inhibit error messages by getopt from all MPI processes except rank 0
@@ -86,11 +87,17 @@ int main (int argc, char *argv[])
 
 	bool got_filename=false;
 	string filename;
-	map<string,string> arguments;
+	map<string,string> arguments; /* keys of this map correspond to the parameter names in &setup namelist */
 
 	int curr_opt;
-	while((curr_opt=getopt_long(argc, argv, "o:l:b:s:h", opts, NULL)) != -1)
+	while((curr_opt=getopt_long(
+		argc, argv,
+		"o:l:b:s:h",	/* options that can be specified by single letter (see docs for effect of ':') */
+		opts,
+		NULL)) != -1)
 	{
+		// Keep in mind that the value of 'optarg' changes with every iteration of this loop
+		// => generate copy if needed
 		switch(curr_opt)
 		{
 			case 'o':
@@ -108,6 +115,10 @@ int main (int argc, char *argv[])
 			case 's':
 				/* FIXME: add check to see if user-provided string can be converted to int */
 				arguments["seed"] = optarg;
+				break;
+
+			case 'S':
+				arguments["semaphore_file_name"] = optarg;
 				break;
 
 
@@ -163,12 +174,14 @@ int main (int argc, char *argv[])
     exit(0);
 #endif
 
-    // call the core routine for genesis
-    genmain(filename,arguments,false);
+    // call the core routine for genesis (returns 0 when successful)
+    int sim_core_result = genmain(filename,arguments,false);
 
     MPI_Barrier(MPI_COMM_WORLD);
     MPI_Finalize(); // node turned off
-    return 0;
+
+    // return 0;
+    return(sim_core_result);
 
 #if 0
 	if (argc == 1){

--- a/src/Main/mainwrap.cpp
+++ b/src/Main/mainwrap.cpp
@@ -5,6 +5,8 @@
 #include <iostream>
 #include <map>
 
+#include <getopt.h>
+
 //#include "VersionInfo.h"
 #include "version.h"
 using namespace std;
@@ -12,21 +14,47 @@ using namespace std;
 // very basic wrapper for genesis. Most of the genesis stuff is moved into genmain.
 #include "hdf5.h"
 
-int main (int argc, char *argv[]) {
+void G4_usage(void)
+{
+    cout << endl
+         << "-------------------------------------------------------------------------------"<< endl;
+    cout << "Usage: genesis4 [-o Output] [-l Lattice] [-b Beamline] [-s Seed] [-h] Input" << endl;
+    cout << "        -o Output:  equivalent to 'rootname' in the setup namelist " << endl;
+    cout << "        -l Lattice:  equivalent to 'lattice' in the setup namelist " << endl;
+    cout << "        -b Beamline: equivalent to 'beamline' in the setup namelist " << endl;
+    cout << "        -s Seed: equivalent to 'seed' in the setup namelist " << endl;
+    cout << "        -h: prints help-info " << endl;
+    cout << "  Any specified command line argument will overwrite" << endl;
+    cout << "  the corresponding entry in the setup namelist" << endl;
+    cout << "-------------------------------------------------------------------------------" << endl;
+}
 
-
-    //-------------------------------------------------------
-    // init MPI and get size etc.
-    //
-    MPI_Init(&argc, &argv); //MPI
-
+void G4_usage_and_stop(void)
+{
     int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank); // assign rank to node
-    string filename (argv[argc-1]);  // input file is always last element
-    map<string,string> arguments;
-    bool ok=true;
 
-	// parse the command line arguments
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if(0==rank)
+        G4_usage();
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Finalize(); // node turned off
+    exit(0);
+}
+
+int main (int argc, char *argv[])
+{
+    //-------------------------------------------------------
+    // init MPI and get rank
+    //
+    int rank;
+    MPI_Init(&argc, &argv); //MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank); // assign rank to node
+
+//    string filename (argv[argc-1]);  // input file is always last element
+//    map<string,string> arguments;
+//    bool ok=true;
 
     if (rank == 0) {
         VersionInfo vi;
@@ -37,6 +65,112 @@ int main (int argc, char *argv[]) {
         cout << "Compile info: " << vi.Build() << endl;
     }
 
+
+	// parse the command line arguments
+	struct option opts[] = {
+		{"output",	required_argument,	NULL, 'o'},
+		{"lattice", 	required_argument,	NULL, 'l'},
+		{"beamline",	required_argument,	NULL, 'b'},
+		{"seed",	required_argument,	NULL, 's'},
+		{"help",	no_argument,		NULL, 'h'},
+		{NULL, 0, NULL, 0}
+	};
+
+	// Inhibit error messages by getopt from all MPI processes except rank 0
+	// Note that these error messages go to stderr, so depending on your simulation setup, they can end up in a different file
+	if(rank!=0) {
+		// Inhibits error message: "unrecognized option '--xyz'"
+		// Also inhibits other messages, for instance msg informing about missing required argument ("option '--xyz' requires an argument")
+		opterr = 0;
+	}
+
+	bool got_filename=false;
+	string filename;
+	map<string,string> arguments;
+
+	int curr_opt;
+	while((curr_opt=getopt_long(argc, argv, "o:l:b:s:h", opts, NULL)) != -1)
+	{
+		switch(curr_opt)
+		{
+			case 'o':
+				arguments["rootname"] = optarg;
+				break;
+
+			case 'l':
+				arguments["lattice"] = optarg;
+				break;
+
+			case 'b':
+				arguments["beamline"] = optarg;
+				break;
+
+			case 's':
+				/* FIXME: add check to see if user-provided string can be converted to int */
+				arguments["seed"] = optarg;
+				break;
+
+
+			case 'h':
+                                G4_usage_and_stop();
+				break;
+
+			case '?': /* fall-through */
+			default:
+				if(rank==0) {
+					cout << "*** error: unknown command line option specified ***" << endl;
+				}
+                                G4_usage_and_stop();
+				break;
+		}
+	}
+
+	/* NOTE: GNU getopt functions permute argv, unless requested to not do so (POSIXLY_CORRECT environment variable). 'optind' points to the first non-option argument. */
+	if(optind<argc)
+	{
+		got_filename=true;
+		filename = argv[optind];
+		// cout << "input file name: " << filename << endl;
+	}
+
+#if 0
+    if(rank==0) {
+        cout << endl << "### reporting options ###" << endl;
+
+        if(got_filename)
+            cout << "filename: " << filename << endl;
+        else
+            cout << "no input file specified" << endl;
+
+        map<string,string>::iterator it;
+        for(it = arguments.begin(); it != arguments.end(); ++it) {
+            cout << it->first << ": " << it->second << endl;
+        }
+        cout << "### DONE ###" << endl;
+    }
+#endif
+
+    if(!got_filename) {
+        if(rank==0)
+            cout << "*** error: no input file provided -- execution of GENESIS will end ***" << endl;
+
+        G4_usage_and_stop();
+    }
+
+#if 0
+    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Finalize(); // node turned off
+    exit(0);
+#endif
+
+    // call the core routine for genesis
+    genmain(filename,arguments,false);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Finalize(); // node turned off
+    return 0;
+
+#if 0
 	if (argc == 1){
         if (rank==0) {
             cout << "*** Error: No input file specified - Execution of Genesis will end" << endl;
@@ -96,9 +230,9 @@ int main (int argc, char *argv[]) {
 	  if (ok) {genmain(filename,arguments,false); }   //
 	}
 
-	MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(MPI_COMM_WORLD);
     MPI_Finalize(); // node turned off
 
     return 0;
-
+#endif
 }

--- a/src/Util/SemaFile.cpp
+++ b/src/Util/SemaFile.cpp
@@ -1,0 +1,32 @@
+#include <cstdio>
+#include <iostream>
+#include <fstream>
+#include <mpi.h>
+
+#include "SemaFile.h"
+
+using namespace std;
+
+SemaFile::SemaFile() {
+	MPI_Comm_rank(MPI_COMM_WORLD, &my_rank_);
+}
+SemaFile::~SemaFile() { }
+
+void SemaFile::remove(string fn) {
+	if (0==my_rank_) {
+		// to be implemented: use std::remove to delete semaphore file
+	}
+}
+
+void SemaFile::put(string fn) {
+	if (0==my_rank_) {
+		ofstream ofs;
+		ofs.open(fn, ofstream::out);
+		if(!ofs) {
+			cout << "error generating semaphore file " << fn << endl;
+		}
+		ofs.close();
+	}
+}
+
+


### PR DESCRIPTION
* Added new parser for command line options
* Added semaphore file functionality:
  - Can be controlled either by two new options in &setup or by specifying name using new command line option --semaphore-file (then there is no need to modify the input file)
  - File is generated only after successful simulation run
* Exit code of G4 binary now depends on simulation status: returns 0 if successful, 1 in case of error