### PR TITLE
Code to write out the 'crsource' before and after filtering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ Version 4.5.1 has been released. Part of it is this Change Log file, which will 
 - 20220218: New command line parser
 - 20220218: Added support for semaphore file. If requested, this file is written at the end of a successful simulation run.
 - 20220218: Exit code of GENESIS binary now depends on status (0 for success, 1 in case of error)
+- 20220319: Debug code for dumping of crsource fields before and after filtering (parameters are in "track" command, WARNING: generated files are very large, about twice as large as a complete field dump)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
 # CL, 2022-03-19: settings for developers
-#set(CMAKE_VERBOSE_MAKEFILE ON)
-#add_compile_options(-Wall -Wextra)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+add_compile_options(-Wall -Wextra)
 
 # OpenMPI: preprocessor macro to disable C++ interface (then we don't have to link libmpi_cxx)
 add_compile_definitions(OMPI_SKIP_MPICXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
 # CL, 2022-03-19: settings for developers
-set(CMAKE_VERBOSE_MAKEFILE ON)
-add_compile_options(-Wall -Wextra)
+#set(CMAKE_VERBOSE_MAKEFILE ON)
+#add_compile_options(-Wall -Wextra)
 
 # OpenMPI: preprocessor macro to disable C++ interface (then we don't have to link libmpi_cxx)
 add_compile_definitions(OMPI_SKIP_MPICXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
 # CL, 2022-03-19: settings for developers
-set(CMAKE_VERBOSE_MAKEFILE ON)
-add_compile_options(-Wall -Wextra)
+# set(CMAKE_VERBOSE_MAKEFILE ON)
+# add_compile_options(-Wall -Wextra)
 
 # OpenMPI: preprocessor macro to disable C++ interface (then we don't have to link libmpi_cxx)
 add_compile_definitions(OMPI_SKIP_MPICXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ set(CMAKE_CXX_EXTENTIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
+# CL, 2022-03-19: settings for developers
+set(CMAKE_VERBOSE_MAKEFILE ON)
+add_compile_options(-Wall -Wextra)
+
 # OpenMPI: preprocessor macro to disable C++ interface (then we don't have to link libmpi_cxx)
 add_compile_definitions(OMPI_SKIP_MPICXX)
 
@@ -126,6 +130,7 @@ add_library(genesis13 STATIC
         src/IO/SDDSBeam.cpp
         src/IO/writeBeamHDF5.cpp
         src/IO/writeFieldHDF5.cpp
+        src/IO/HDF5_cwc.cpp
         src/Loading/ImportBeam.cpp
         src/Loading/ImportField.cpp
         src/Loading/LoadBeam.cpp

--- a/include/FieldSolver.h
+++ b/include/FieldSolver.h
@@ -10,6 +10,8 @@
 #include <fftw3.h>
 #endif
 
+#include <hdf5.h>
+
 
 class Field;
 class Beam;
@@ -20,6 +22,18 @@ class Beam;
 
 using namespace std;
 
+class HDF5_CollWriteCore;
+struct dump_settings {
+	int dump_en;
+
+	// one instance per obj. in the file
+	HDF5_CollWriteCore *pcwc;
+	HDF5_CollWriteCore *pcwc_filt;
+
+	// parameters describing the data layout along the first axis of the HDF5 data objs to be generated (=longitudinal axis)
+	int curr_slice;
+	int nstot;
+};
 
 class FieldSolver{
  public:
@@ -43,13 +57,15 @@ class FieldSolver{
    bool hasPlan;
    complex<double> *in, *out;
    fftw_plan p,pi;
-
 #endif
-   void filterSourceTerm();
+
+   int cntr_;
+   void dump_crsource(struct dump_settings *, HDF5_CollWriteCore *);
+
+   void filterSourceTerm(struct dump_settings *);
    void ADI(vector<complex< double > > &);
    void tridagx(vector<complex< double > > &);
    void tridagy(vector<complex< double > > &);
-   
 };
 
 #endif

--- a/include/FieldSolver.h
+++ b/include/FieldSolver.h
@@ -24,7 +24,7 @@ using namespace std;
 
 class HDF5_CollWriteCore;
 struct dump_settings {
-	int dump_en;
+	bool do_dump;
 
 	// one instance per obj. in the file
 	HDF5_CollWriteCore *pcwc;
@@ -43,6 +43,7 @@ class FieldSolver{
    void advance(double, Field *, Beam *, Undulator *);
    void init(int);
    void initSourceFilter(bool, double, double, double);
+   void initSourceFilter_DbgDumpSettings(bool, int, string);
 
  private:
    int ngrid;
@@ -59,7 +60,10 @@ class FieldSolver{
    fftw_plan p,pi;
 #endif
 
-   int cntr_;
+   bool crsource_dump_en_;
+   int crsource_dump_every_;
+   string crsource_dump_rootname_;
+   int call_cntr_adv_;
    void dump_crsource(struct dump_settings *, HDF5_CollWriteCore *);
 
    void filterSourceTerm(struct dump_settings *);

--- a/include/FieldSolver.h
+++ b/include/FieldSolver.h
@@ -65,6 +65,7 @@ class FieldSolver{
    string crsource_dump_rootname_;
    int call_cntr_adv_;
    void dump_crsource(struct dump_settings *, HDF5_CollWriteCore *);
+   void dump_filter(struct dump_settings *, hid_t);
 
    void filterSourceTerm(struct dump_settings *);
    void ADI(vector<complex< double > > &);

--- a/include/HDF5_cwc.h
+++ b/include/HDF5_cwc.h
@@ -1,0 +1,34 @@
+#include <iostream>
+//#include <iomanip>
+//#include <fstream>
+#include <string>
+//#include <math.h>
+//#include <complex>
+
+
+#ifndef __GEN_HDF5_CWC__
+#define __GEN_HDF5_CWC__
+
+//#include <mpi.h>
+#include <hdf5.h>
+//#include "HDF5base.h"
+//#include "Field.h"
+
+using namespace std;
+
+class HDF5_CollWriteCore {
+public:
+	HDF5_CollWriteCore();
+	~HDF5_CollWriteCore();
+	void create_and_prepare(hid_t gid, string dataset, string unit, vector<hsize_t> *totalsize, unsigned long ndim);
+	void write(vector<double> *data, vector<hsize_t> *count, vector<hsize_t> *offset);
+	void close(void);
+
+private:
+	unsigned long ndim_;
+	hid_t did_;
+	bool did_valid_;
+};
+
+#endif
+

--- a/include/Track.h
+++ b/include/Track.h
@@ -29,6 +29,8 @@ class Track{
  private:
    void usage();
    bool atob(string);
+   bool ExtractArgBool(map<string,string> *, const string, bool *);
+   bool ExtractArgInt(map<string,string> *, const string, int *);
 
    double zstop,slen,s0;
    int output_step,dumpFieldStep,dumpBeamStep,sort_step,bunchharm;

--- a/src/Core/FieldSolver.cpp
+++ b/src/Core/FieldSolver.cpp
@@ -158,6 +158,24 @@ void FieldSolver::advance(double delz, Field *field, Beam *beam, Undulator *und)
     pcwc_filt = new HDF5_CollWriteCore;
     pcwc->create_and_prepare(fid, "crsource", " ", &totalsize, datadim);
     pcwc_filt->create_and_prepare(fid, "crsource_filtered", " ", &totalsize, datadim);
+
+    const int filt_datadim=1;
+    vector<hsize_t> filt_totalsize(filt_datadim,0);
+    filt_totalsize[0] = ngrid*ngrid; // sigmoid is vector<double>
+    HDF5_CollWriteCore cwc_f;
+    cwc_f.create_and_prepare(fid, "f", " ", &filt_totalsize, filt_datadim);
+    vector<hsize_t> my_offset(filt_datadim,0);
+    vector<hsize_t> my_count(filt_datadim,0);
+    // Only process with rank=0 is writing (controlled by setting count to zero on all others).
+    // Note that we still need to call write member of HDF5_CollWriteCore on all processes.
+    if(mpi_rank==0)
+      my_count[0] = ngrid*ngrid;
+    else
+      my_count[0] = 0;
+
+    // sigmoid_[0] = 1+mpi_rank; // test code: which node is writing the data???
+    cwc_f.write(&sigmoid_, &my_count, &my_offset);
+    cwc_f.close();
   }
   ds.do_dump = dump_at_this_step;
   ds.pcwc = pcwc;

--- a/src/Core/FieldSolver.cpp
+++ b/src/Core/FieldSolver.cpp
@@ -102,6 +102,8 @@ void FieldSolver::initSourceFilter(bool do_filter,double xc, double yc, double s
     }
 #endif
 }
+
+/* function is called from Track::init as the next run is being set up/configured */
 bool FieldSolver::initSourceFilter_DbgDumpSettings(bool dump_en_in, int step_in, string rootname_in, string what)
 {
   int mpi_rank;
@@ -153,6 +155,7 @@ bool FieldSolver::initSourceFilter_DbgDumpSettings(bool dump_en_in, int step_in,
     return(false);
   }
 
+  call_cntr_adv_ = 0; // new run: reset integration step counter
   crsource_dump_every_ = step_in;
   crsource_dump_rootname_ = rootname_in;
   if(crsource_dump_filter_ || crsource_dump_crsource_ || crsource_dump_crsource_filt_)

--- a/src/IO/HDF5_cwc.cpp
+++ b/src/IO/HDF5_cwc.cpp
@@ -1,0 +1,104 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <mpi.h>
+#include <hdf5.h>
+
+#include "HDF5_cwc.h"
+
+using namespace std;
+
+extern bool MPISingle;
+
+/*
+ * Write code with full flexibility (datatype is double)
+ * . ndim is the dimensionality of the data
+ * . totalsize is the size of the object in the file
+ * . offset and count describe what this process writes
+ */
+HDF5_CollWriteCore::HDF5_CollWriteCore()
+{
+	ndim_=0;
+	did_=0;
+	did_valid_=false;
+}
+HDF5_CollWriteCore::~HDF5_CollWriteCore()
+{
+	if(did_valid_) {
+		cout << "warning: HDF5 obj still open" << endl;
+		close();
+	}
+}
+
+void HDF5_CollWriteCore::create_and_prepare(hid_t gid, string dataset, string unit, vector<hsize_t> *totalsize, unsigned long ndim)
+{
+  if (totalsize->size()!=ndim)
+  {
+     cout << "obj size: incorrect element count" << endl;
+     return;
+  }
+
+  // step 1 - create dataset
+  hid_t filespace=H5Screate_simple(ndim,&(*totalsize)[0],NULL);
+  did_=H5Dcreate(gid,dataset.c_str(),H5T_NATIVE_DOUBLE,filespace,H5P_DEFAULT,H5P_DEFAULT,H5P_DEFAULT);   
+  H5Sclose(filespace);
+
+  // write attribute
+  hid_t aid = H5Screate(H5S_SCALAR);
+  hid_t atype = H5Tcopy(H5T_C_S1);
+  H5Tset_size(atype, unit.size());
+  H5Tset_strpad(atype,H5T_STR_NULLTERM);
+  hid_t attr = H5Acreate2(did_,"unit",atype,aid,H5P_DEFAULT,H5P_DEFAULT);
+  H5Awrite(attr,atype,unit.c_str());
+  H5Sclose(aid);
+  H5Tclose(atype);
+  H5Aclose(attr);
+
+  ndim_=ndim;
+  did_valid_=true;
+}
+
+void HDF5_CollWriteCore::write(vector<double> *data, vector<hsize_t> *count, vector<hsize_t> *offset)
+{
+  if(!did_valid_)
+  {
+    cout << "error: no valid HDF5 object is assigned to this instance" << endl;
+    return;
+  }
+  if ((count->size()!=ndim_) && (offset->size()!=ndim_))
+  {
+    cout << "offset/count vectors: incorrect element count" << endl;
+    return;
+  }
+
+  // step 2 - file space
+  hid_t memspace=H5Screate_simple(ndim_,&(*count)[0],NULL);
+
+  // step 3 - set up hyperslab for file transfer.
+  hid_t filespace=H5Dget_space(did_);
+  H5Sselect_hyperslab(filespace,H5S_SELECT_SET,&(*offset)[0],NULL,&(*count)[0],NULL);
+
+
+  // step 4 - set up transfer and write
+  hid_t pid =  H5Pcreate(H5P_DATASET_XFER);
+  if (!MPISingle){
+    H5Pset_dxpl_mpio(pid,H5FD_MPIO_COLLECTIVE);    
+  }
+  H5Dwrite(did_,H5T_NATIVE_DOUBLE,memspace,filespace,pid,&data->at(0));
+  H5Sclose(memspace);
+  H5Sclose(filespace);
+  H5Pclose(pid);
+}
+
+void HDF5_CollWriteCore::close(void)
+{
+  if(!did_valid_)
+    return;
+
+  // close all HDF5 stuff 
+  H5Dclose(did_);
+  did_=0;
+  did_valid_=false;
+}
+

--- a/src/Main/Track.cpp
+++ b/src/Main/Track.cpp
@@ -151,13 +151,19 @@ bool Track::init(int inrank, int insize, map<string,string> *arg, Beam *beam, ve
   }
 
   // initializing filtering of the fields
+#ifndef FFTW
+  if(rank==0) {
+    cout << "*** Requested filter_diff, however this GENESIS binary does was built without FFTW. => filter_diff setting has no effect. ***" << endl;
+  }
+#endif
   for (int ifld = 0; ifld < field->size(); ifld++){
       field->at(ifld)->solver.initSourceFilter(difffilt,filtx,filty,filtsig);
   }
+
+
   // call to gencore to do the actual tracking.  
   Gencore core;
   core.run(file.c_str(),beam,field,und,isTime,isScan, filter);
-
 
   delete und;
    


### PR DESCRIPTION
Dumping of 'crsource' is enabled by setting the currently undocumented parameter 'dbg_dump_crsource' to true and dbg_dump_crsource_step controls how often the file is generated (in number of integration steps, the default value is 100).
If filter_diff is 'false', these settings have no effect (because the source term filtering is then inactive).

Warning: The generated files are very large (larger than a complete field dump).

This is the structure of the generated HDF5 files (example for a simulation with ngrid=315):
```
% h5ls -r test.1000.crsource.h5
/                        Group
/crsource                Dataset {36864, 99225, 2}
/crsource_filtered       Dataset {36864, 99225, 2}
/filter                  Dataset {99225}
```