### PR TITLE
code implementing "start" semaphore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ Version 4.5.1 has been released. Part of it is this Change Log file, which will 
 - 20220218: New command line parser
 - 20220218: Added support for semaphore file. If requested, this file is written at the end of a successful simulation run.
 - 20220218: Exit code of GENESIS binary now depends on status (0 for success, 1 in case of error)
+- 20220329: Added additional "start" semaphore file that is written after &setup block was processed
 
 

--- a/include/Setup.h
+++ b/include/Setup.h
@@ -41,7 +41,8 @@ class Setup: public StringProcessing{
    bool   outputEnergy();
    bool   outputAux();
    bool   outputFieldDump();
-   bool   getSemaEn();
+   bool   getSemaEnStart();
+   bool   getSemaEnDone();
    void   setSemaFN(string);
    bool   getSemaFN(string *);
 
@@ -79,7 +80,7 @@ class Setup: public StringProcessing{
 
    int seed, rank,npart,nbins,runcount;
 
-   bool sema_file_enabled;
+   bool sema_file_enabled_start, sema_file_enabled_done;
    string sema_file_name; // user-defined name of semaphore file, if empty: file name will be derived in function getSemaFN
 };
 
@@ -127,5 +128,6 @@ inline void   Setup::BWF_set_inc(int in)
 	beam_write_slices_inc=in;
 }
 
-inline bool   Setup::getSemaEn() { return sema_file_enabled; }
+inline bool   Setup::getSemaEnStart() { return sema_file_enabled_start; }
+inline bool   Setup::getSemaEnDone()  { return sema_file_enabled_done; }
 #endif

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -163,6 +163,22 @@ int genmain (string mainstring, map<string,string> &comarg, bool split) {
           }
           if (!setup->init(rank,&argument,lattice, filter)){ break;}
           meta_latfile=setup->getLattice();
+
+          /* successfully processed "&setup" block => generate start semaphore file if requested to do so by user */
+          if (setup->getSemaEnStart()) {
+            string semafile_fn_started;
+            SemaFile sema;
+            if (rank==0) {
+              if(setup->getSemaFN(&semafile_fn_started)) {
+                semafile_fn_started+="start"; // "started"-type semaphore file have additional filename suffix
+                sema.put(semafile_fn_started);
+                cout << endl << "generating 'start' semaphore file " << semafile_fn_started << endl << endl;
+              } else {
+                cout << endl << "error: not writing 'start' semaphore file, filename not defined" << endl << endl;
+              }
+            }
+          }
+
           continue;
       }
 
@@ -365,7 +381,7 @@ int genmain (string mainstring, map<string,string> &comarg, bool split) {
         bool semafile_en=false;
         string semafile_fn;
         bool semafile_fn_valid=false;
-        if ((semafile_en=setup->getSemaEn())) {
+        if ((semafile_en=setup->getSemaEnDone())) {
           if(successful_run) {
             if(setup->getSemaFN(&semafile_fn)) {
               semafile_fn_valid=true;

--- a/src/Main/Setup.cpp
+++ b/src/Main/Setup.cpp
@@ -36,7 +36,8 @@ Setup::Setup()
   // count of runs in conjunction of calls of altersetup
   runcount = 0;
 
-  sema_file_enabled=false;
+  sema_file_enabled_start=false;
+  sema_file_enabled_done=false;
 }
 
 Setup::~Setup(){}
@@ -66,6 +67,8 @@ void Setup::usage(){
   cout << " bool exclude_current_output = true" << endl;
   cout << " bool exclude_field_dump = false" << endl;
   cout << " bool write_semaphore_file = false" << endl;
+  cout << " bool write_semaphore_file_done = false" << endl;
+  cout << " bool write_semaphore_file_started = false" << endl;
   cout << " string semaphore_file_name = <derived from 'rootname'>" << endl;
   cout << "&end" << endl << endl;
   return;
@@ -90,6 +93,7 @@ bool Setup::init(int inrank, map<string,string> *arg, Lattice *lat, FilterDiagno
   if (arg->find("shotnoise")!=end){shotnoise  = atob(arg->at("shotnoise"));  arg->erase(arg->find("shotnoise"));}
   if (arg->find("beam_global_stat")!=end)  {beam_global_stat  = atob(arg->at("beam_global_stat"));   arg->erase(arg->find("beam_global_stat"));}
   if (arg->find("field_global_stat")!=end) {field_global_stat = atob(arg->at("field_global_stat"));  arg->erase(arg->find("field_global_stat"));}
+
   if (arg->find("exclude_spatial_output")!=end)   {exclude_spatial_output  = atob(arg->at("exclude_spatial_output"));   arg->erase(arg->find("exclude_spatial_output"));}
   if (arg->find("exclude_fft_output")!=end)       {exclude_fft_output      = atob(arg->at("exclude_fft_output"));       arg->erase(arg->find("exclude_fft_output"));}
   if (arg->find("exclude_intensity_output")!=end) {exclude_intensity_output= atob(arg->at("exclude_intensity_output")); arg->erase(arg->find("exclude_intensity_output"));}
@@ -97,13 +101,18 @@ bool Setup::init(int inrank, map<string,string> *arg, Lattice *lat, FilterDiagno
   if (arg->find("exclude_aux_output")!=end)       {exclude_aux_output      = atob(arg->at("exclude_aux_output"));       arg->erase(arg->find("exclude_aux_output"));}
   if (arg->find("exclude_current_output")!=end)   {exclude_current_output  = atob(arg->at("exclude_current_output"));   arg->erase(arg->find("exclude_current_output"));}
   if (arg->find("exclude_field_dump")!=end)   {exclude_field_dump  = atob(arg->at("exclude_field_dump"));   arg->erase(arg->find("exclude_field_dump"));}
-  if (arg->find("write_semaphore_file")!=end)   {sema_file_enabled  = atob(arg->at("write_semaphore_file"));   arg->erase(arg->find("write_semaphore_file"));}
+
+  if (arg->find("write_semaphore_file")!=end)   {sema_file_enabled_done  = atob(arg->at("write_semaphore_file"));   arg->erase(arg->find("write_semaphore_file"));}
+  /* alias for write_semaphore_file */
+  if (arg->find("write_semaphore_file_done")!=end)   {sema_file_enabled_done  = atob(arg->at("write_semaphore_file_done"));   arg->erase(arg->find("write_semaphore_file_done"));}
+  if (arg->find("write_semaphore_file_started")!=end)   {sema_file_enabled_start  = atob(arg->at("write_semaphore_file_started"));   arg->erase(arg->find("write_semaphore_file_started"));}
   if (arg->find("semaphore_file_name")!=end) {
-    // Providing a file name for the semaphore file always switches it on, overriding 'write_semaphore_file' flag.
+    // Providing a file name for the semaphore file always switches on writing the "done" semaphore file, overriding 'write_semaphore_file' flag.
     // This allows to switch on semaphore functionality just by specifying corresponding command line argument -- no modification of G4 input file needed.
-    sema_file_enabled = true;
+    sema_file_enabled_done = true;
     setSemaFN(arg->at("semaphore_file_name")); arg->erase(arg->find("semaphore_file_name"));
   }
+  /* Note: if requested, semaphore file of type "started" is generated in GenMain after successfully returning from Setup::init */
 
   // same code also in AlterSetup.cpp
   if (arg->find("beam_write_slices_from")!=end) {

--- a/src/Util/SemaFile.cpp
+++ b/src/Util/SemaFile.cpp
@@ -21,6 +21,8 @@ void SemaFile::remove(string fn) {
 void SemaFile::put(string fn) {
 	if (0==my_rank_) {
 		ofstream ofs;
+
+		// Note: already existing files are truncated
 		ofs.open(fn, ofstream::out);
 		if(!ofs) {
 			cout << "error generating semaphore file " << fn << endl;


### PR DESCRIPTION
File extension is `.semastart`, it is controlled by newly introduced `write_semaphore_file_started` parameter.
For the already existing "done" semaphore, the extension is `.sema` and it is controlled by the specifying one of the equivalent parameters `write_semaphore_file_done` or `write_semaphore_file`. Currently, only writing of "done" semaphore can be enabled using command line option.
