### PR TITLE
namelist 'field_manipulator'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Version 4.5.1 has been released. Part of it is this Change Log file, which will be updated in the future releases.
 
 ## Unreleased:
+### [4.6.1-beta] - 2022/12/06
+- add "field_manipulator" feature, currently it can be used to scale to power of the light field
+
 ### [4.6.1-beta] - 2022/02/16
 - Moved the calculation for the output file from the Beam and Field class to the class Diagnostic.cpp. This class interacts with the class  in Output.cpp so that the output class does not need to know the name of the field to be written. This informationis provided by the new class in Diagnostic.cpp. That way it gets easier to add additional output, where only on location needs to be changed (namely the derived classes in DiagnostUser.cpp)
 - Command line arguments are now overwriting the correpsonding input the main input file. Supported are the output file root name, the lattice file, the beam line and the seed for the shot noise power.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ set(CMAKE_CXX_EXTENTIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
+# developer options
+set(CMAKE_VERBOSE_MAKEFILE ON)
+add_compile_options(-Wall -Wextra)
+
 # OpenMPI: preprocessor macro to disable C++ interface (then we don't have to link libmpi_cxx)
 add_compile_definitions(OMPI_SKIP_MPICXX)
 
@@ -136,6 +140,7 @@ add_library(genesis13 STATIC
         src/Main/AlterSetup.cpp
         src/Main/Dump.cpp
         src/Main/EField.cpp
+        src/Main/FieldManipulator.cpp
         src/Main/GenMain.cpp
         src/Main/mainwrap.cpp
         src/Main/Parser.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
 # developer options
-set(CMAKE_VERBOSE_MAKEFILE ON)
-add_compile_options(-Wall -Wextra)
+#set(CMAKE_VERBOSE_MAKEFILE ON)
+#add_compile_options(-Wall -Wextra)
 
 # OpenMPI: preprocessor macro to disable C++ interface (then we don't have to link libmpi_cxx)
 add_compile_definitions(OMPI_SKIP_MPICXX)

--- a/include/FieldManipulator.h
+++ b/include/FieldManipulator.h
@@ -12,7 +12,7 @@
 
 #include "StringProcessing.h"
 #include "Setup.h"
-#include "Time.h"
+#include "GenTime.h"
 #include "Profile.h"
 #include "GaussHermite.h"
 #include "Field.h"

--- a/include/FieldManipulator.h
+++ b/include/FieldManipulator.h
@@ -1,0 +1,33 @@
+#ifndef __GENESIS_FIELDMANIPULATOR_H
+#define __GENESIS_FIELDMANIPULATOR_H
+
+#include <iostream>
+#include <vector>
+#include <math.h>
+#include <stdlib.h>
+#include <string>
+#include <map>
+#include <fstream>
+#include <complex>
+
+#include "StringProcessing.h"
+#include "Setup.h"
+#include "Time.h"
+#include "Profile.h"
+#include "GaussHermite.h"
+#include "Field.h"
+
+using namespace std;
+
+class FieldManipulator: public StringProcessing {
+public:
+	FieldManipulator();
+	~FieldManipulator();
+
+	bool init(int, int, map<string,string> *,vector<Field *> *, Setup *, Time *, Profile *);
+
+private:
+	void usage(void);
+};
+
+#endif // __GENESIS_FIELDMANIPULATOR_H

--- a/src/Main/FieldManipulator.cpp
+++ b/src/Main/FieldManipulator.cpp
@@ -1,0 +1,81 @@
+#include <cmath>
+#include "FieldManipulator.h"
+
+FieldManipulator::FieldManipulator() { }
+FieldManipulator::~FieldManipulator() { }
+
+
+void FieldManipulator::usage(){
+  cout << "List of keywords for FIELD_MANIPULATOR" << endl;
+  cout << "&field_manipulator" << endl;
+  cout << " int harm = 1" << endl;
+  cout << " double scale_power = 1.0" << endl;
+  cout << "&end" << endl << endl;
+  return;
+}
+
+bool FieldManipulator::init(int rank, int size, map<string,string> *arg, vector<Field *> *fieldin,  Setup *setup, Time *time, Profile *prof)
+{
+	map<string,string>::iterator end=arg->end();
+	int harm = 1;
+	double scale_P = 1.0;
+
+	// extract parameters
+	if (arg->find("harm")!=end)         {harm    = atoi(arg->at("harm").c_str());        arg->erase(arg->find("harm"));}
+	if (arg->find("scale_power")!=end)  {scale_P = atof(arg->at("scale_power").c_str()); arg->erase(arg->find("scale_power"));}
+
+	if (arg->size()!=0){
+		if (rank==0) {
+			cout << "*** Error: Unknown elements in &field_manipulator" << endl;
+			this->usage();
+		}
+		return(false);
+	}
+
+
+	// check parameters
+	if(!(harm>0)) {
+		if (rank==0) {
+			cout << "*** Error in field_manipulator: harmonic must be positive" << endl;
+		}
+		return(false);
+	}
+	if(scale_P<0) {
+		if (rank==0) {
+			cout << "*** Error in field_manipulator: scale_power must not be negative" << endl;
+		}
+		return(false);
+	}
+
+
+	// identify the harmonic field to be manipulated
+	// (and stop if there is no field for requested harmonic)
+	Field *p_fld=NULL;
+	for (int k=0; k<fieldin->size(); k++) {
+		if(fieldin->at(k)->harm == harm) {
+			p_fld = fieldin->at(k);
+			break;
+		}
+	}
+	if(NULL==p_fld) {
+		if (rank==0) {
+			cout << "*** Error in field_manipulator: there is no field for requested harmonic " << harm << endl;
+		}
+		return(false);
+	}
+
+
+	// *** process field ***
+	if(rank==0) {
+		cout << "Scaling power in field harmonic=" << harm << " by factor " << scale_P << " ..." << endl;
+	}
+	int ngrid = p_fld->ngrid;
+	double scale_field = sqrt(scale_P);
+	for(int idslice=0; idslice < time->getNodeNSlice(); idslice++) {
+		for(int k=0; k<ngrid*ngrid; k++) {
+			p_fld->field[idslice].at(k) *= scale_field;
+		}
+	}
+
+	return(true);
+}

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -44,6 +44,7 @@
 #include "Wake.h"
 #include "Diagnostic.h"
 #include "SemaFile.h"
+#include "FieldManipulator.h"
 
 #include <sstream>
 
@@ -242,6 +243,16 @@ int genmain (string mainstring, map<string,string> &comarg, bool split) {
 	    LoadField *loadfield=new LoadField;
             if (!loadfield->init(rank,size,&argument,&field,setup,timewindow,profile)){ break;}
 	    delete loadfield;
+            continue;  
+          }  
+
+          //----------------------------------------------------
+          // field manipulation
+
+	  if (element.compare("&field_manipulator")==0){
+	    FieldManipulator *q = new FieldManipulator;
+            if (!q->init(rank,size,&argument,&field,setup,timewindow,profile)){ break;}
+	    delete q;
             continue;  
           }  
 	 


### PR DESCRIPTION
Adds 'field_manipulator' namelist.

Currently only scaling of power of the light field is supported, but I plan to implement some additional features in the future.

Example:
```
&field_manipulator
   harm = 1
   scale_power = 0.1
&end
```
==> Power of field in fundamental is attenuated by one order of magnitude. By putting multiple of these blocks, different harmonics can be scaled by different factors (for instance for harmonic lasing studies).

The manipulation is done in memory, avoiding time-intensive file-based field manipulation, which uses the steps: (i) dumping of fields to files, (ii) manipulation of the files, and (iii) loading fields into GENESIS again to continue with the simulation.


During the merge, CHANGELOG.md will generate a conflict that has to be manually resolved (order of the text blocks).