### PR TITLE
adding new parameter outputdir to &setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Version 4.5.1 has been released. Part of it is this Change Log file, which will be updated in the future releases.
 
 ## Unreleased:
+### [4.6.1-beta] - 2022/12/30
+- added parameter "outputdir" to "&setup": allows to define directory (relative or absolute) where to store the simulation output
+
 ### [4.6.1-beta] - 2022/12/06
 - add "field_manipulator" feature, currently it can be used to scale to power of the light field
 

--- a/include/HDF5base.h
+++ b/include/HDF5base.h
@@ -27,6 +27,7 @@ class HDF5Base{
   int s0;
   hsize_t ds; // size in s for 2D array inwrite buffer
 
+  bool create_outfile(hid_t *, string);
   
   // function from output and wrideHDF5beam/field
   void writeBuffer(hid_t,string,string,vector<double> *);

--- a/include/Setup.h
+++ b/include/Setup.h
@@ -53,6 +53,7 @@ class Setup: public StringProcessing{
    //   bool   getInputFileNameField(string *);
    bool   getRootName(string *);
    void   setRootName(string *);
+   bool   RootName_to_FileName(string *, string *);
    int getCount();
    void incrementCount();
    string getLattice();
@@ -69,7 +70,7 @@ class Setup: public StringProcessing{
 
  private:
    void usage();
-   string rootname,lattice,beamline,partfile,fieldfile;
+   string rootname,outputdir,lattice,beamline,partfile,fieldfile;
    double gamma0,lambda0,delz;
    bool one4one,shotnoise;
    bool beam_global_stat, field_global_stat;

--- a/include/dump.h
+++ b/include/dump.h
@@ -25,10 +25,11 @@ class Dump: public StringProcessing{
    Dump();
    virtual ~Dump();
    bool init(int, int, map<string,string> *, Setup *, Beam *beam, vector<Field *> *field);
+
  private:
    void usage();
-   string dumpfield,dumpbeam;
-   int rank,size;
+   // string dumpfield,dumpbeam;
+   // int rank,size;
 };
 
 

--- a/src/IO/Output.cpp
+++ b/src/IO/Output.cpp
@@ -55,6 +55,7 @@ void Output::open(string file, int s0_in, int ds_in)
   s0=s0_in;
   ds=ds_in;
 
+#if 0
   // create the file for parallel access
   hid_t pid = H5Pcreate(H5P_FILE_ACCESS);
 
@@ -63,6 +64,9 @@ void Output::open(string file, int s0_in, int ds_in)
   }
   fid=H5Fcreate(file.c_str(),H5F_ACC_TRUNC, H5P_DEFAULT,pid);
   H5Pclose(pid);
+#else
+  create_outfile(&fid, file);
+#endif
 }
 
 

--- a/src/IO/writeBeamHDF5.cpp
+++ b/src/IO/writeBeamHDF5.cpp
@@ -25,6 +25,7 @@ void WriteBeamHDF5::write(string fileroot, Beam *beam)
     rank=0;
   }
 
+#if 0
   char filename[100];
   sprintf(filename,"%s.par.h5",fileroot.c_str()); 
   if (rank == 0) { cout << "Writing particle distribution to file: " <<filename << " ..." << endl;} 
@@ -35,6 +36,12 @@ void WriteBeamHDF5::write(string fileroot, Beam *beam)
   }
   fid=H5Fcreate(filename,H5F_ACC_TRUNC, H5P_DEFAULT,pid); 
   H5Pclose(pid);
+#else
+  string filename;
+  filename = fileroot+".par.h5";
+  if (rank == 0) { cout << "Writing particle distribution to file: " <<filename << " ..." << endl;} 
+  create_outfile(&fid, filename);
+#endif
 
   s0=rank;
   int ntotal=size*beam->beam.size();

--- a/src/IO/writeFieldHDF5.cpp
+++ b/src/IO/writeFieldHDF5.cpp
@@ -44,8 +44,8 @@ void WriteFieldHDF5::write(string fileroot, vector<Field *> *field){
 void WriteFieldHDF5::writeMain(string fileroot, Field *field){
 
 
- 
 
+#if 0
   char filename[100];
   sprintf(filename,"%s.fld.h5",fileroot.c_str()); 
   if (rank == 0) { cout << "Writing field distribution to file: " <<filename << " ..." << endl;} 
@@ -56,6 +56,12 @@ void WriteFieldHDF5::writeMain(string fileroot, Field *field){
   }
   fid=H5Fcreate(filename,H5F_ACC_TRUNC, H5P_DEFAULT,pid); 
   H5Pclose(pid);
+#else
+  string filename;
+  filename = fileroot+".fld.h5";
+  if (rank == 0) { cout << "Writing field distribution to file: " <<filename << " ..." << endl;} 
+  create_outfile(&fid, filename);
+#endif
 
   s0=rank;
   int ntotal=size*field->field.size();

--- a/src/Main/Dump.cpp
+++ b/src/Main/Dump.cpp
@@ -2,12 +2,7 @@
 #include "writeFieldHDF5.h"
 #include "writeBeamHDF5.h"
 
-Dump::Dump()
-{
-  dumpfield="";
-  dumpbeam ="";
-}
-
+Dump::Dump(){}
 Dump::~Dump(){}
 
 void Dump::usage(){
@@ -22,24 +17,22 @@ void Dump::usage(){
 
 bool Dump::init(int inrank, int insize, map<string,string> *arg, Setup *setup, Beam *beam, vector<Field *> *field)
 {
-
-  rank=inrank;
-  size=insize;
-
- 
+  string dumpfield, dumpbeam;
   map<string,string>::iterator end=arg->end();
 
   if (arg->find("field")!=end){dumpfield=arg->at("field"); arg->erase(arg->find("field"));}
   if (arg->find("beam")!=end) {dumpbeam =arg->at("beam");  arg->erase(arg->find("beam"));}
   if (arg->size()!=0){
-    if (rank==0){ cout << "*** Error: Unknown elements in &write" << endl; this->usage();}
+    if (inrank==0){ cout << "*** Error: Unknown elements in &write" << endl; this->usage();}
     return false;
   }
 
   
   if (dumpfield.size()>0){
    WriteFieldHDF5 dump;
-   dump.write(dumpfield,field);
+   string completefn;
+   setup->RootName_to_FileName(&completefn, &dumpfield);
+   dump.write(completefn,field);
   }
   if (dumpbeam.size()>0){
    WriteBeamHDF5 dump;
@@ -47,12 +40,10 @@ bool Dump::init(int inrank, int insize, map<string,string> *arg, Setup *setup, B
    // propagate beam dump settings before initiating writing procedure
    beam->setWriteFilter(setup->BWF_get_enabled(), setup->BWF_get_from(), setup->BWF_get_to(), setup->BWF_get_inc());
 
-   dump.write(dumpbeam,beam);
+   string completefn;
+   setup->RootName_to_FileName(&completefn, &dumpbeam);
+   dump.write(completefn,beam);
   }
 
   return true;
-
-
 }
-
-

--- a/src/Main/Setup.cpp
+++ b/src/Main/Setup.cpp
@@ -206,7 +206,7 @@ void Setup::BWF_load_defaults()
 
 /* returns true if filename for semaphore file was generated */
 bool Setup::getSemaFN(string *fnout) {
-	// user-defined filename overrides the logic to derive from rootname
+	// user-defined filename overrides the logic to derive from rootname (also a user-provided 'outputdir' parameter does not have an effect here)
 	if(! sema_file_name.empty()) {
 		*fnout = sema_file_name;
 		return(true);
@@ -215,8 +215,10 @@ bool Setup::getSemaFN(string *fnout) {
 	if(rootname.empty()) {
 		return(false);
 	}
-	*fnout = rootname;
-	*fnout += ".sema";
+	string t;
+	t = rootname;
+	t += ".sema";
+	RootName_to_FileName(fnout, &t);
 	return(true);
 }
 void Setup::setSemaFN(string fn_in) {

--- a/src/Main/Setup.cpp
+++ b/src/Main/Setup.cpp
@@ -4,6 +4,7 @@
 Setup::Setup()
 {
   rootname="";
+  outputdir="";
   lattice="";
   beamline="";
   partfile="";
@@ -47,6 +48,7 @@ void Setup::usage(){
   cout << "List of keywords for SETUP" << endl;
   cout << "&setup" << endl;
   cout << " string rootname = <taken from command line>" << endl;
+  cout << " string outputdir = <empty>" << endl;
   cout << " string lattice  = <taken from command line>" << endl;
   cout << " string beamline = <empty>" << endl;
   cout << " double gamma0 = 5800/0.511" << endl;
@@ -80,6 +82,7 @@ bool Setup::init(int inrank, map<string,string> *arg, Lattice *lat, FilterDiagno
   map<string,string>::iterator end=arg->end();
 
   if (arg->find("rootname")!=end){rootname = arg->at("rootname"); arg->erase(arg->find("rootname"));}
+  if (arg->find("outputdir")!=end){outputdir = arg->at("outputdir"); arg->erase(arg->find("outputdir"));}
   if (arg->find("lattice")!=end) {lattice  = arg->at("lattice");  arg->erase(arg->find("lattice"));}
   if (arg->find("beamline")!=end){beamline = arg->at("beamline"); arg->erase(arg->find("beamline"));}
   if (arg->find("lattice")!=end) {lattice  = arg->at("lattice");  arg->erase(arg->find("lattice"));}
@@ -173,6 +176,21 @@ bool Setup::getRootName(string *filename)
     *filename+=ss.str();
   }
   return true; 
+}
+bool Setup::RootName_to_FileName(string *fn_out, string *rootname)
+{
+  // If 'outputdir' parameter not specified
+  // ==> do not change string
+  if (outputdir.size()<1) {
+    *fn_out = *rootname;
+    return true;
+  }
+
+  string t;
+  t = outputdir + "/" + *rootname;
+  *fn_out = t;
+
+  return true;
 }
 
 void Setup::BWF_load_defaults()

--- a/src/Main/Track.cpp
+++ b/src/Main/Track.cpp
@@ -76,11 +76,6 @@ bool Track::init(int inrank, int insize, map<string,string> *arg, Beam *beam, ve
   filter.beam.harm = bunchharm;
   if (output_step < 1) { output_step=1; }
 
-  string file;
-  setup->getRootName(&file);
-  file.append(".out.h5");
-
-
  
   Undulator *und = new Undulator;
 
@@ -137,6 +132,10 @@ bool Track::init(int inrank, int insize, map<string,string> *arg, Beam *beam, ve
 
   // call to gencore to do the actual tracking.  
   Gencore core;
+  string rn, file;
+  setup->getRootName(&rn);
+  setup->RootName_to_FileName(&file, &rn);
+  file.append(".out.h5");
   core.run(file.c_str(),beam,field,und,isTime,isScan, filter);
 
 


### PR DESCRIPTION
Patch adding a new parameter `outputdir` to `&setup`.

This parameter can be used to better organize the files as generated output files (such as `.out.h5`, `.fld.h5`, `.par.h5`, or `.sema`) go to the specified directory.

If the parameter is not specified, the behavior of the code remains unchanged.


In addition, the three code blocks using `H5Fcreate` to generate an output file were replaced by calls to a newly added function in `H5FBase` class. This enables to add diagnostics code in the future. Currently the function prints an error message and returns false if H5Fcreate returns an invalid handle (but the return code is not handled by the calling functions).

One minor issue affecting only users of the new `outputdir` parameter is that the filenames of field/beam dumps written at markers that are stored in `/Meta/Beamdumps/filename*` and `/Meta/Fielddumps/filename*` contain also the path specified in `outputdir`, i.e. the filenames are relative to the current working directory of the simulation run. This will be solved in a second patch.

CHANGELOG.md will generate a merge conflict that has to be resolved manually.