### PR TITLE
Fix crash in Diagnostic code when using fields having different 'ngrid'

### DIFF
--- a/include/Diagnostic.h
+++ b/include/Diagnostic.h
@@ -74,16 +74,43 @@ public:
     virtual void getValues(Beam *, std::map<std::string,std::vector<double> > &, int) =0;
 };
 
+
+
+// For field diagnostics: helper class for management of FFT-related resources
+#ifdef FFTW
+class FFTObj {
+public:
+	FFTObj(int);
+	~FFTObj();
+
+	// The fftw_plan is a pointer, delete copy constructor and copy
+	// assignment operator.
+	// This avoids dangling pointers in object copies (fftw_plan contains
+	// the data locations that were used to prepare the plan).
+	FFTObj(const FFTObj&) = delete;
+	FFTObj& operator= (const FFTObj&) = delete;
+
+	std::complex<double> *in_ {nullptr};
+	std::complex<double> *out_ {nullptr};
+
+	// according to FFTW documentation, fftw_plan is an "opaque pointer type" (https://www.fftw.org/fftw3_doc/Using-Plans.html , 19.01.2023)
+	fftw_plan p_;
+
+private:
+	int rank_;
+	int ngrid_;
+};
+// map holding FFT-related resources for the values of ngrid
+typedef std::map<int,FFTObj *> map_fftobj;
+#endif
+
 class DiagFieldBase{
 protected:
     std::map<std::string, OutputInfo>  tags;  // holds a map with tags and units
     std::map<std::string,bool> filter;        // general map to store the selected flags
     bool global {false};
 #ifdef FFTW
-    std::complex<double> *in;
-    std::complex<double> *out;
-    fftw_plan p;
-    bool hasPlan {false};
+    map_fftobj fftobj;
 #endif
 
 public:
@@ -117,6 +144,11 @@ public:
     DiagField() = default; // this is needed since the harmonics can be changed
     std::map<std::string,OutputInfo> getTags(FilterDiagnostics &filter);
     void getValues(Field *, std::map<std::string,std::vector<double> > &, int) ;
+
+#ifdef FFTW
+    void cleanup(void);
+    int obtain(int ngrid, complex<double> **in, complex<double> **out, fftw_plan *pp);
+#endif
 };
 
 //----------------------------------------

--- a/include/Diagnostic.h
+++ b/include/Diagnostic.h
@@ -146,8 +146,8 @@ public:
     void getValues(Field *, std::map<std::string,std::vector<double> > &, int) ;
 
 #ifdef FFTW
-    void cleanup(void);
-    int obtain(int ngrid, complex<double> **in, complex<double> **out, fftw_plan *pp);
+    void cleanup_FFT_resources(void);
+    int obtain_FFT_resources(int ngrid, complex<double> **in, complex<double> **out, fftw_plan *pp);
 #endif
 };
 

--- a/src/Core/Diagnostic.cpp
+++ b/src/Core/Diagnostic.cpp
@@ -450,7 +450,7 @@ FFTObj::~FFTObj() {
 	delete [] out_;
 }
 
-void DiagField::cleanup(void)
+void DiagField::cleanup_FFT_resources(void)
 {
 	for(auto &[k,obj]: fftobj) {
 		delete obj;
@@ -458,7 +458,7 @@ void DiagField::cleanup(void)
 	fftobj.clear();
 }
 
-int DiagField::obtain(int ngrid, complex<double> **in, complex<double> **out, fftw_plan *pp)
+int DiagField::obtain_FFT_resources(int ngrid, complex<double> **in, complex<double> **out, fftw_plan *pp)
 {
 	int rank=0;
 	bool verbose=false;
@@ -585,7 +585,7 @@ void DiagField::getValues(Field *field,std::map<std::string,std::vector<double> 
     complex<double> *in  = nullptr;
     complex<double> *out = nullptr;
     fftw_plan p;
-    obtain(ngrid, &in, &out, &p);
+    obtain_FFT_resources(ngrid, &in, &out, &p);
 #endif
 
 

--- a/src/Core/Diagnostic.cpp
+++ b/src/Core/Diagnostic.cpp
@@ -422,6 +422,81 @@ void DiagBeam::getValues(Beam *beam,std::map<std::string,std::vector<double> >&v
 //---------------------------------------------------------
 // diagnostic calculation - field
 
+FFTObj::FFTObj(int ngrid)
+{
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
+
+	// this is severe error: print on *all* ranks
+	if(ngrid<0) {
+		cerr << "Error: enforcing ngrid>0" << endl;
+		ngrid=1;
+	}
+	in_ = new complex<double>[ngrid * ngrid];
+	out_ = new complex<double>[ngrid * ngrid];
+	p_ = fftw_plan_dft_2d(ngrid, ngrid,
+	    reinterpret_cast<fftw_complex *>(in_),
+	    reinterpret_cast<fftw_complex *>(out_),
+	    FFTW_FORWARD, FFTW_ESTIMATE /* FFTW_MEASURE */);
+	ngrid_ = ngrid;
+}
+
+FFTObj::~FFTObj() {
+	if(rank_==0) {
+		cout << "~FFTObj" << endl;
+	}
+
+	fftw_destroy_plan(p_);
+	delete [] in_;
+	delete [] out_;
+}
+
+void DiagField::cleanup(void)
+{
+	for(auto &[k,obj]: fftobj) {
+		delete obj;
+	}
+	fftobj.clear();
+}
+
+int DiagField::obtain(int ngrid, complex<double> **in, complex<double> **out, fftw_plan *pp)
+{
+	int rank=0;
+	bool verbose=false;
+	bool exists=false;
+
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+	// see if the entry already exists
+	auto end = fftobj.end();
+	auto ele = fftobj.find(ngrid);
+	exists = (ele!=end);
+
+	if(!exists) {
+		/* set up new entry */
+		FFTObj *n = new FFTObj(ngrid);
+
+		// FIXME: 'insert' also returns iterator to newly inserted element
+		fftobj.insert({ngrid, n});
+		ele = fftobj.find(ngrid);
+
+		if(verbose && (rank==0)) {
+			cout << "created FFT obj for ngrid="<<ngrid<<endl;
+		}
+	} else {
+		if(verbose && (rank==0)) {
+			cout << "getting existing FFT obj for ngrid="<<ngrid<<endl;
+		}
+	}
+
+	// cout << "ngrid=" << ele->first << endl;
+	*in = ele->second->in_;
+	*out = ele->second->out_;
+	*pp = ele->second->p_;
+
+	return(0);
+}
+
+
 std::map<std::string,OutputInfo> DiagField::getTags(FilterDiagnostics & filter_in){
 
     tags.clear();
@@ -484,18 +559,6 @@ void DiagField::getValues(Field *field,std::map<std::string,std::vector<double> 
     int is0 = 0;
     int ngrid = field->ngrid;
 
-
-#ifdef FFTW
-    if (!hasPlan) {
-        in = new complex<double>[ngrid * ngrid];
-        out = new complex<double>[ngrid * ngrid];
-        p = fftw_plan_dft_2d(ngrid, ngrid, reinterpret_cast<fftw_complex *>(in), reinterpret_cast<fftw_complex *>(out),
-                             FFTW_FORWARD, FFTW_MEASURE);
-        hasPlan = true;
-    }
-#endif
-
-
     double ks=4.*asin(1)/field->xlambda;
     double scl=field->dgrid*eev/ks;
     double scltheta=field->xlambda/ngrid/field->dgrid;
@@ -511,13 +574,20 @@ void DiagField::getValues(Field *field,std::map<std::string,std::vector<double> 
     double g_y2=0;
     double g_ff=0;
     double g_inten=0;
+
 #ifdef FFTW
     double f_pow=0;
     double f_x1=0;
     double f_x2=0;
     double f_y1=0;
     double f_y2=0;
+
+    complex<double> *in  = nullptr;
+    complex<double> *out = nullptr;
+    fftw_plan p;
+    obtain(ngrid, &in, &out, &p);
 #endif
+
 
     for (auto const &slice :field->field) {
         int is = (ns + is0 - field->first) % ns;


### PR DESCRIPTION
Running with fields having different 'ngrid' causes crashes, either with SIGSEGV in Diagnostic code or a crash due to heap issues at a later time. For instance if the first field (h=1) has ngrid=51 and the second field (for example h=3) has ngrid=201.

This patch fixes these issues by adding code to manage separate FFTW resources (plan, in/out buffers) for all ngrid values.
