### PR TITLE
Improve handling of error conditions in class Sorting

### DIFF
--- a/include/Sorting.h
+++ b/include/Sorting.h
@@ -30,6 +30,7 @@ class Sorting{
 
  private:
   void update_stats(unsigned long long &, unsigned long long &);
+  void globalSort_completion_msg(void);
   void fillPushVectors(vector< vector< Particle > > *);
   void localSort(vector< vector< Particle > > *);
   int centerShift(vector< vector< Particle > > *);
@@ -45,6 +46,8 @@ class Sorting{
   bool doshift,dosort,globalframe;
   vector<double> pushforward,pushbackward;
 
+  unsigned long long stat_max_xfer_size;
+  int sort_round; // was introduced for generation of filenames for debug info
 };
 
 

--- a/include/Sorting.h
+++ b/include/Sorting.h
@@ -29,7 +29,7 @@ class Sorting{
 
 
  private:
-
+  void update_stats(unsigned long long &, unsigned long long &);
   void fillPushVectors(vector< vector< Particle > > *);
   void localSort(vector< vector< Particle > > *);
   int centerShift(vector< vector< Particle > > *);

--- a/src/Util/Sorting.cpp
+++ b/src/Util/Sorting.cpp
@@ -155,19 +155,16 @@ void Sorting::globalSort(vector <vector <Particle> > *rec)
   if (size==1) { return; } // no need to transfer if only one node is used.
   
 
+  unsigned long long my_nforward=pushforward.size();
+  unsigned long long my_nbackward=pushbackward.size();
+  unsigned long long my_nxfer=my_nforward+my_nbackward;
+  unsigned long long global_nxfer=0;
+  MPI_Allreduce(&my_nxfer,&global_nxfer,1,MPI_UNSIGNED_LONG_LONG,MPI_SUM,MPI_COMM_WORLD);
+  if (global_nxfer == 0){ return; }	
+
   int maxiter=size-1;  
-  int nforward=pushforward.size();
-  int nbackward=pushbackward.size();
-  int ntotal=nforward+nbackward;
-  int nreduce=0;
-
-
-  MPI_Allreduce(&ntotal,&nreduce,1,MPI_INT,MPI_SUM,MPI_COMM_WORLD);
-
-  if (nreduce == 0){ return; }	
-
   while(maxiter>0){
-    if (rank==0) {cout << "Sorting: Transferring " << nreduce/6 << " particles to other nodes at iteration " << size-maxiter << endl;}
+    if (rank==0) {cout << "Sorting: Transferring " << global_nxfer/6 << " particles to other nodes at iteration " << size-maxiter << endl;}
 
 
 
@@ -204,13 +201,12 @@ void Sorting::globalSort(vector <vector <Particle> > *rec)
      }
  
      maxiter--;
-     nforward=pushforward.size();
-     nbackward=pushbackward.size();
-     ntotal=nforward+nbackward;
-     nreduce=0;
-
-     MPI_Allreduce(&ntotal,&nreduce,1,MPI_INT,MPI_SUM,MPI_COMM_WORLD);
-     if (nreduce == 0){  return; }
+     my_nforward=pushforward.size();
+     my_nbackward=pushbackward.size();
+     my_nxfer=my_nforward+my_nbackward;
+     global_nxfer=0;
+     MPI_Allreduce(&my_nxfer,&global_nxfer,1,MPI_UNSIGNED_LONG_LONG,MPI_SUM,MPI_COMM_WORLD);
+     if (global_nxfer == 0){ return; }
   }
   pushforward.clear();
   pushbackward.clear();

--- a/src/Util/Sorting.cpp
+++ b/src/Util/Sorting.cpp
@@ -159,12 +159,16 @@ void Sorting::globalSort(vector <vector <Particle> > *rec)
   unsigned long long my_nbackward=pushbackward.size();
   unsigned long long my_nxfer=my_nforward+my_nbackward;
   unsigned long long global_nxfer=0;
-  MPI_Allreduce(&my_nxfer,&global_nxfer,1,MPI_UNSIGNED_LONG_LONG,MPI_SUM,MPI_COMM_WORLD);
+  unsigned long long max_nforward=0, max_nbackward=0, max_nxfer=0;
+  MPI_Allreduce(&my_nxfer,&global_nxfer,      1,MPI_UNSIGNED_LONG_LONG,MPI_SUM,MPI_COMM_WORLD);
+  MPI_Allreduce(&my_nforward,&max_nforward,   1,MPI_UNSIGNED_LONG_LONG,MPI_MAX,MPI_COMM_WORLD);
+  MPI_Allreduce(&my_nbackward,&max_nbackward, 1,MPI_UNSIGNED_LONG_LONG,MPI_MAX,MPI_COMM_WORLD);
+  max_nxfer = (max_nforward>max_nbackward) ? max_nforward : max_nbackward;
   if (global_nxfer == 0){ return; }	
 
   int maxiter=size-1;  
   while(maxiter>0){
-    if (rank==0) {cout << "Sorting: Transferring " << global_nxfer/6 << " particles to other nodes at iteration " << size-maxiter << endl;}
+    if (rank==0) {cout << "Sorting: Transferring " << global_nxfer/6 << " particles to other nodes at iteration " << size-maxiter << " (largest single transfer contains " << max_nxfer/6 << " particles)" << endl;}
 
 
 
@@ -205,7 +209,11 @@ void Sorting::globalSort(vector <vector <Particle> > *rec)
      my_nbackward=pushbackward.size();
      my_nxfer=my_nforward+my_nbackward;
      global_nxfer=0;
-     MPI_Allreduce(&my_nxfer,&global_nxfer,1,MPI_UNSIGNED_LONG_LONG,MPI_SUM,MPI_COMM_WORLD);
+     max_nforward=max_nbackward=max_nxfer=0;
+     MPI_Allreduce(&my_nxfer,&global_nxfer,      1,MPI_UNSIGNED_LONG_LONG,MPI_SUM,MPI_COMM_WORLD);
+     MPI_Allreduce(&my_nforward,&max_nforward,   1,MPI_UNSIGNED_LONG_LONG,MPI_MAX,MPI_COMM_WORLD);
+     MPI_Allreduce(&my_nbackward,&max_nbackward, 1,MPI_UNSIGNED_LONG_LONG,MPI_MAX,MPI_COMM_WORLD);
+     max_nxfer = (max_nforward>max_nbackward) ? max_nforward : max_nbackward;
      if (global_nxfer == 0){ return; }
   }
   pushforward.clear();

--- a/src/Util/Sorting.cpp
+++ b/src/Util/Sorting.cpp
@@ -4,10 +4,18 @@ extern bool MPISingle;
  
 #include <algorithm>
 
+#include <fstream>
+#include <sstream>
+
+// #define SORT_DBG
+
 Sorting::Sorting()
 {
   dosort=false;
   doshift=false;
+
+  sort_round=0;
+  stat_max_xfer_size=0;
 }
 
 Sorting::~Sorting(){
@@ -145,6 +153,7 @@ void Sorting::localSort(vector <vector <Particle> > * recdat)  // most arguments
 // helper function for globalSort function
 void Sorting::update_stats(unsigned long long &global_nxfer, unsigned long long &max_nxfer)
 {
+  /* numbers of doubles in transfer buffers (1 Particle corresponds to 6 doubles) */
   unsigned long long my_nforward=pushforward.size();
   unsigned long long my_nbackward=pushbackward.size();
   unsigned long long my_nxfer=my_nforward+my_nbackward;
@@ -156,11 +165,20 @@ void Sorting::update_stats(unsigned long long &global_nxfer, unsigned long long 
   max_nxfer = (max_nforward>max_nbackward) ? max_nforward : max_nbackward;
 }
 
+// helper function for globalSort function
+void Sorting::globalSort_completion_msg(void)
+{
+  unsigned long long global_max_xfer_size;
+  MPI_Allreduce(&stat_max_xfer_size, &global_max_xfer_size, 1,MPI_UNSIGNED_LONG_LONG,MPI_MAX,MPI_COMM_WORLD);
+  if(rank==0) {
+    cout << "Info: globalSort complete, largest transfer was " << global_max_xfer_size << " doubles" << endl;
+  }
+}
+
 // routine which moves all particles, which are misplaced in the given domain of the node to other nodes.
 // the methods is an iterative bubble sort, pushing excess particles to next node. There the fitting particles are collected the rest moved further.
 void Sorting::globalSort(vector <vector <Particle> > *rec)
 {
-
   this->fillPushVectors(rec);   // here is the actual sorting to fill the vectore pushforward and pushbackward
   if (rank==(size-1)) { pushforward.clear(); }        
   if (rank==0) { pushbackward.clear(); }
@@ -172,9 +190,11 @@ void Sorting::globalSort(vector <vector <Particle> > *rec)
   update_stats(global_nxfer, max_nxfer);
   if (global_nxfer == 0){ return; }	
 
+  sort_round=0;
+  stat_max_xfer_size=0;
   int maxiter=size-1;  
   while(maxiter>0){
-    if (rank==0) {cout << "Sorting: Transferring " << global_nxfer/6 << " particles to other nodes at iteration " << size-maxiter << " (largest single transfer contains " << max_nxfer/6 << " particles)" << endl;}
+     if (rank==0) {cout << "Sorting: Transferring " << global_nxfer/6 << " particles to other nodes at iteration " << size-maxiter << " (largest single transfer contains " << max_nxfer/6 << " particles)" << endl;}
 
 
 
@@ -194,6 +214,12 @@ void Sorting::globalSort(vector <vector <Particle> > *rec)
       
   // step two - pairing ranks (1,2) (3,4) etc
 
+#ifdef SORT_DBG
+     // dbg
+     update_stats(global_nxfer, max_nxfer);
+     if (rank==0) {cout << "DBG Sorting: Transferring " << global_nxfer/6 << " particles to other nodes at iteration " << size-maxiter << " (largest single transfer contains " << max_nxfer/6 << " particles)" << endl;}
+#endif // SORT_DBG
+
      transfer = true;
      if (((rank % 2) == 1) && (rank == (size -1))) { transfer = false; }  // last core for an even number
      if (rank==0) { transfer = false; }                                  // as well as first core.
@@ -210,26 +236,46 @@ void Sorting::globalSort(vector <vector <Particle> > *rec)
        }
      }
  
-     maxiter--;
+     maxiter--; sort_round++;
      update_stats(global_nxfer, max_nxfer);
-     if (global_nxfer == 0){ return; }
+     if (global_nxfer == 0) {
+       globalSort_completion_msg();
+       return;
+     }
   }
   pushforward.clear();
   pushbackward.clear();
+
+  globalSort_completion_msg();
+
   return;
-
-
-
-  
-
 }
 
 
 void Sorting::send(int target, vector<double> *data)
 {
-  int ndata=data->size();
+  unsigned long long ndata=data->size();
 
-  MPI_Send(&ndata,1,MPI_INT,target,0,MPI_COMM_WORLD);
+#ifdef SORT_DBG
+  stringstream ss;
+  ofstream ofs;
+  ss << "sortdbg." << sort_round << "." << rank;
+  ofs.open(ss.str(), ofstream::out);
+  ofs << ndata << endl;
+  ofs.close();
+#endif // SORT_DBG
+
+  // Prevent transfer sizes resulting in overflow (MPI_Send argument 'count' has data type 'int').
+  unsigned long long maxint = numeric_limits<int>::max();
+  if(ndata>maxint) {
+    cout << "Sorting::send (on rank " <<rank<< "): Number of data in send buffer is " <<ndata<< ", exceeding maximum MPI transfer size of INT_MAX (too many particles to be moved to neighboring rank), exiting." << endl;
+    MPI_Abort(MPI_COMM_WORLD,1);
+  }
+
+  if(stat_max_xfer_size<ndata)
+    stat_max_xfer_size=ndata;
+
+  MPI_Send(&ndata,1,MPI_UNSIGNED_LONG_LONG,target,0,MPI_COMM_WORLD);
     //  MPI::COMM_WORLD.Send( &ndata,1,MPI::INT,target,0);
   if (ndata == 0) {
     return;
@@ -239,18 +285,18 @@ void Sorting::send(int target, vector<double> *data)
 }
 
 
- void Sorting::recv(int source, vector <vector <Particle> > *rec ,vector<double> *olddata)
+void Sorting::recv(int source, vector <vector <Particle> > *rec ,vector<double> *olddata)
 {
-
-  double shift=slen;
-  if(globalframe){shift=0;}
+   double shift=slen;
+   if(globalframe){shift=0;}
 
    MPI_Status status;
-   int ndata=0;
+   unsigned long long ndata=0;
 
-   MPI_Recv(&ndata,1,MPI_INT,source,0,MPI_COMM_WORLD, &status);
+   MPI_Recv(&ndata,1,MPI_UNSIGNED_LONG_LONG,source,0,MPI_COMM_WORLD, &status);
    //   MPI::COMM_WORLD.Recv(&ndata,1,MPI::INT,source,0,status);
-   if (ndata==0) {  // no data received.
+   if (ndata==0) {
+     // no data transfer expected -> leave
      return;
    }
 

--- a/src/Util/Sorting.cpp
+++ b/src/Util/Sorting.cpp
@@ -142,10 +142,22 @@ void Sorting::localSort(vector <vector <Particle> > * recdat)  // most arguments
 }
 
 
+// helper function for globalSort function
+void Sorting::update_stats(unsigned long long &global_nxfer, unsigned long long &max_nxfer)
+{
+  unsigned long long my_nforward=pushforward.size();
+  unsigned long long my_nbackward=pushbackward.size();
+  unsigned long long my_nxfer=my_nforward+my_nbackward;
+  unsigned long long max_nforward=0, max_nbackward=0;
+
+  MPI_Allreduce(&my_nxfer,     &global_nxfer,  1,MPI_UNSIGNED_LONG_LONG,MPI_SUM,MPI_COMM_WORLD);
+  MPI_Allreduce(&my_nforward,  &max_nforward,  1,MPI_UNSIGNED_LONG_LONG,MPI_MAX,MPI_COMM_WORLD);
+  MPI_Allreduce(&my_nbackward, &max_nbackward, 1,MPI_UNSIGNED_LONG_LONG,MPI_MAX,MPI_COMM_WORLD);
+  max_nxfer = (max_nforward>max_nbackward) ? max_nforward : max_nbackward;
+}
 
 // routine which moves all particles, which are misplaced in the given domain of the node to other nodes.
 // the methods is an iterative bubble sort, pushing excess particles to next node. There the fitting particles are collected the rest moved further.
-
 void Sorting::globalSort(vector <vector <Particle> > *rec)
 {
 
@@ -155,15 +167,9 @@ void Sorting::globalSort(vector <vector <Particle> > *rec)
   if (size==1) { return; } // no need to transfer if only one node is used.
   
 
-  unsigned long long my_nforward=pushforward.size();
-  unsigned long long my_nbackward=pushbackward.size();
-  unsigned long long my_nxfer=my_nforward+my_nbackward;
   unsigned long long global_nxfer=0;
-  unsigned long long max_nforward=0, max_nbackward=0, max_nxfer=0;
-  MPI_Allreduce(&my_nxfer,&global_nxfer,      1,MPI_UNSIGNED_LONG_LONG,MPI_SUM,MPI_COMM_WORLD);
-  MPI_Allreduce(&my_nforward,&max_nforward,   1,MPI_UNSIGNED_LONG_LONG,MPI_MAX,MPI_COMM_WORLD);
-  MPI_Allreduce(&my_nbackward,&max_nbackward, 1,MPI_UNSIGNED_LONG_LONG,MPI_MAX,MPI_COMM_WORLD);
-  max_nxfer = (max_nforward>max_nbackward) ? max_nforward : max_nbackward;
+  unsigned long long max_nxfer=0;
+  update_stats(global_nxfer, max_nxfer);
   if (global_nxfer == 0){ return; }	
 
   int maxiter=size-1;  
@@ -205,15 +211,7 @@ void Sorting::globalSort(vector <vector <Particle> > *rec)
      }
  
      maxiter--;
-     my_nforward=pushforward.size();
-     my_nbackward=pushbackward.size();
-     my_nxfer=my_nforward+my_nbackward;
-     global_nxfer=0;
-     max_nforward=max_nbackward=max_nxfer=0;
-     MPI_Allreduce(&my_nxfer,&global_nxfer,      1,MPI_UNSIGNED_LONG_LONG,MPI_SUM,MPI_COMM_WORLD);
-     MPI_Allreduce(&my_nforward,&max_nforward,   1,MPI_UNSIGNED_LONG_LONG,MPI_MAX,MPI_COMM_WORLD);
-     MPI_Allreduce(&my_nbackward,&max_nbackward, 1,MPI_UNSIGNED_LONG_LONG,MPI_MAX,MPI_COMM_WORLD);
-     max_nxfer = (max_nforward>max_nbackward) ? max_nforward : max_nbackward;
+     update_stats(global_nxfer, max_nxfer);
      if (global_nxfer == 0){ return; }
   }
   pushforward.clear();


### PR DESCRIPTION
Handle integer overflow situations that can happen during sorting for simulations with high beam current (several kA), long wavelengths (several micro-meters), and strong chicanes.
While our current simulation parameters still have some margin to these problematic conditions, it is preferrable to stop with a user-friendly error message. If everything went well, at the end of the global sorting process the maximum seen transfer size is reported.


These changes implement a user-friendly error message, for example:
`Sorting::send (on rank 33): Number of data in send buffer is 2176251030, exceeding maximum MPI transfer size of INT_MAX (too many particles to be moved to neighboring rank), exiting.`


Before, the symptoms of integer overflow were for instance:
```
[max-exfl194:192212] *** An error occurred in MPI_Send
[max-exfl194:192212] *** reported by process [3030646785,33]
[max-exfl194:192212] *** on communicator MPI_COMM_WORLD
[max-exfl194:192212] *** MPI_ERR_COUNT: invalid count argument
[max-exfl194:192212] *** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
[max-exfl194:192212] ***    and potentially your MPI job)
```

Another example (from `Sorting::recv`):
```
terminate called after throwing an instance of 'std::length_error'
  what():  cannot create std::vector larger than max_size()
[max-exfl194:192213] *** Process received signal ***
[max-exfl194:192213] Signal: Aborted (6)
[max-exfl194:192213] Signal code:  (-6)
[max-exfl194:192213] [ 0] /lib64/libpthread.so.0(+0xf630)[0x2ac826081630]
[max-exfl194:192213] [ 1] /lib64/libc.so.6(gsignal+0x37)[0x2ac8262c4387]
[max-exfl194:192213] [ 2] /lib64/libc.so.6(abort+0x148)[0x2ac8262c5a78]
[max-exfl194:192213] [ 3] /software/gcc/9.3/lib64/libstdc++.so.6(+0xa2693)[0x2ac825f32693]
[max-exfl194:192213] [ 4] /software/gcc/9.3/lib64/libstdc++.so.6(+0xae106)[0x2ac825f3e106]
[max-exfl194:192213] [ 5] /software/gcc/9.3/lib64/libstdc++.so.6(+0xae171)[0x2ac825f3e171]
[max-exfl194:192213] [ 6] /software/gcc/9.3/lib64/libstdc++.so.6(+0xae3c5)[0x2ac825f3e3c5]
[max-exfl194:192213] [ 7] /software/gcc/9.3/lib64/libstdc++.so.6(_ZSt20__throw_length_errorPKc+0x3d)[0x2ac825f34d04]
[max-exfl194:192213] [ 8] ./genesis4[0x4965ac]
[max-exfl194:192213] [ 9] ./genesis4[0x49672b]
[max-exfl194:192213] [10] ./genesis4[0x496ac7]
[max-exfl194:192213] [11] ./genesis4[0x433b94]
[max-exfl194:192213] [12] ./genesis4[0x40fc90]
[max-exfl194:192213] [13] ./genesis4[0x40bffe]
[max-exfl194:192213] [14] /lib64/libc.so.6(__libc_start_main+0xf5)[0x2ac8262b0555]
[max-exfl194:192213] [15] ./genesis4[0x40cabf]
[max-exfl194:192213] *** End of error message ***
```