### PR TITLE
Use the correct speed of light

### DIFF
--- a/postprocessor/matlab/xgenplot.m
+++ b/postprocessor/matlab/xgenplot.m
@@ -133,7 +133,7 @@ global xgenstat
             x(i)=sqrt(xsig-xmean*xmean);
 
         end 
-        x=x*xgenstat.ds/3e8;
+        x=x*xgenstat.ds/299792458.0;
     else
         
         for i=1:nz

--- a/src/Core/Diagnostic.cpp
+++ b/src/Core/Diagnostic.cpp
@@ -725,7 +725,7 @@ void DiagField::getValues(Field *field,std::map<std::string,std::vector<double> 
         f_x1*=scltheta;
         f_y1*=scltheta;
 #endif
-        g_pow *=scl*scl/vacimp*field->slicelength/3e8;
+        g_pow *=scl*scl/vacimp*field->slicelength/299792458.0;
         norm = 1./static_cast<double>(size*field->field.size());
         g_inten *= norm*eev*eev/ks/ks/vacimp;
         g_ff*=norm;

--- a/src/Core/EFieldSolver.cpp
+++ b/src/Core/EFieldSolver.cpp
@@ -63,7 +63,7 @@ void EFieldSolver::longRange(Beam *beam, double gamma0, double aw) {
     MPI_Allgather(&work1.front(),nsize,MPI_DOUBLE,&fcurrent.front(),nsize,MPI_DOUBLE, MPI_COMM_WORLD);
     MPI_Allgather(&work2.front(),nsize,MPI_DOUBLE, &fsize.front(),nsize,MPI_DOUBLE, MPI_COMM_WORLD);
 
-    double scl = beam->slicelength/2./asin(1)/3e8/2/8.85e-12;  // convert to units of electron rest mass.
+    double scl = beam->slicelength/2./asin(1)/299792458.0/2/8.85e-12;  // convert to units of electron rest mass.
 
     for (int i=0; i < nsize; i++){
         double EFld = 0;

--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -499,7 +499,7 @@ void Field::diagnostics(bool output)
 #endif
       }
 
-      energy[idx]=acc_power*scl*scl/vacimp*slicelength/3e8;  // energy 
+      energy[idx]=acc_power*scl*scl/vacimp*slicelength/299792458.0;  // energy 
       if (acc_power == 0){
 	acc_power=1.;
       }

--- a/src/IO/SDDSBeam.cpp
+++ b/src/IO/SDDSBeam.cpp
@@ -225,7 +225,7 @@ bool SDDSBeam::init(int inrank, int insize, map<string,string> *arg, Beam *beam,
 
 
   for (int i=0; i<nsize; i++){
-    t[i]*=-3e8;       // convert to positin in meters
+    t[i]*=-299792458.0;       // convert to positin in meters
     g[i]+=1.;         // convert from kinetic energy to total energy
   }
 
@@ -397,7 +397,7 @@ bool SDDSBeam::init(int inrank, int insize, map<string,string> *arg, Beam *beam,
     // step 2 - calculate the current and number of particles.
     int ncount = beam->beam.at(islice).size();
     int mpart;
-    beam->current[islice]=static_cast<double>(ncount)*dQ*3e8/dslen;
+    beam->current[islice]=static_cast<double>(ncount)*dQ*299792458.0/dslen;
     if (one4one){
       npart=static_cast<int>(round(beam->current[islice]*lambda*sample/ce));
       mpart=npart;

--- a/src/Loading/Profile.cpp
+++ b/src/Loading/Profile.cpp
@@ -374,7 +374,7 @@ string ProfileFile::init(int rank, map<string,string>*arg)
 
   if (isTime){ 
     for (int i=0; i<xdat.size();i++){
-      xdat[i]*=3e8;         // scale time variable to space varial by multiplying the speed of light
+      xdat[i]*=299792458.0;         // scale time variable to space varial by multiplying the speed of light
     }  
   }
   
@@ -533,7 +533,7 @@ bool ProfileFileMulti::setup(int rank, map<string,string> *arg, map<string, Prof
 
 	if(isTime) {
 		for(unsigned j=0; j<xdata.size(); j++)
-			xdata[j]*=3e8; // using same speed_of_light value as in ProfileFile, to avoid that different results are obtained with &profile_file and &profile_file_multi
+			xdata[j]*=299792458.0; // using same speed_of_light value as in ProfileFile, to avoid that different results are obtained with &profile_file and &profile_file_multi
 	}
 	if(revert) {
 		if(rank==0)

--- a/src/Main/Wake.cpp
+++ b/src/Main/Wake.cpp
@@ -275,7 +275,7 @@ void Wake::singleWakeResistive(int rank)
  	double t = kappa/sqrt(1+kappa*kappa*gamma*gamma);
         double lambdaRe=coef*sqrt(t)*sqrt(1.-t*gamma);
   	double lambdaIm=coef*sqrt(t)*sqrt(1.+t*gamma)-kappa*kappa*radius*0.5/s0/s0;
-	double nomi=2.*kappa/(3e8*radius*s0)/(lambdaRe*lambdaRe+lambdaIm*lambdaIm);
+	double nomi=2.*kappa/(299792458.0*radius*s0)/(lambdaRe*lambdaRe+lambdaIm*lambdaIm);
 	Zre[i]=lambdaRe*nomi;
 	Zim[i]=-lambdaIm*nomi;
      }
@@ -293,7 +293,7 @@ void Wake::singleWakeResistive(int rank)
       for (int i =0; i<nk; i++){       
            double kappa=(i+1.)*kappamax/nk;  // value of kappa	 
  	   double t = kappa/sqrt(1+kappa*kappa*gamma*gamma);
-           double scale=2.*15.*kappa/(3e8*radius*s0*(2*nq-1));
+           double scale=2.*15.*kappa/(299792458.0*radius*s0*(2*nq-1));
 	   Zre[i]=0;
 	   Zim[i]=0;	 
        // integrate over q-> infty which is actually exp(30)
@@ -317,7 +317,7 @@ void Wake::singleWakeResistive(int rank)
 	  wakeres[i]+=Zre[j]*cos(phi)+Zim[j]*sin(phi);
       }
    }
-   coef=-kappamax/nk/s0*3e8/pi*(vacimp*ce/4/pi); // to scale to SI units
+   coef=-kappamax/nk/s0*299792458.0/pi*(vacimp*ce/4/pi); // to scale to SI units
    coef*=0.5;  // emperical adjustment of amplitude, needs checking!!!!!
 
    for (int i = 0; i < ns; i++){

--- a/xgenesis/xgenplot.m
+++ b/xgenesis/xgenplot.m
@@ -133,7 +133,7 @@ global xgenstat
             x(i)=sqrt(xsig-xmean*xmean);
 
         end 
-        x=x*xgenstat.ds/3e8;
+        x=x*xgenstat.ds/299792458.0;
     else
         
         for i=1:nz


### PR DESCRIPTION
This replaces all instances of `3e8` with `299792458.0` (the speed of light in m/s, exact).