### PR TITLE
display also simulation progress of 0%

### DIFF
--- a/src/Core/Undulator.cpp
+++ b/src/Core/Undulator.cpp
@@ -241,8 +241,13 @@ bool Undulator::advance(int rank)
   int dstepz=static_cast<int> (round(nstepz/10.*zfrac));
   if (dstepz<1){dstepz=1;}
 
-  if (((istepz % dstepz) == 0) && (istepz >0) && (rank==0)){
-    cout << "  Calculation: " <<10*istepz/dstepz << "% done" << endl;
+  // Lechner, 2023-07-27: Changed the condition to display also progress of 0%
+  // (to inform user that simulation is now running)
+  // Remark: First execution of this code block with istepz==0
+  if (((istepz % dstepz) == 0) /* && (istepz >0) */ ) {
+    if (rank==0) {
+      cout << "  Calculation: " <<10*istepz/dstepz << "% done" << endl;
+    }
   }
   return true;
 }


### PR DESCRIPTION
Display also 0% progress of actual simulation.

This makes the program more user-friendly because it is clear that the simulation is now running (and large simulations might need hours until 10% progress is reached which used to be the first progress message).

Example output:
```
Running Core Simulation...
Time-dependent run with 7296 slices for a time window of 1.0051 microns
Initial analysis of electron beam and radiation field...
  Calculation: 0% done
  Calculation: 10% done
  Calculation: 20% done
[..]
```