### PR TITLE
field_manipulator: add support for SPPs

### DIFF
--- a/include/FieldManipulator.h
+++ b/include/FieldManipulator.h
@@ -19,6 +19,14 @@
 
 using namespace std;
 
+class FieldManipulator_SPP_Params {
+public:
+	int harm	{1};
+	double spp_l	{0};
+	int spp_nsect	{0};
+	double spp_phi0	{0};
+};
+
 class FieldManipulator: public StringProcessing {
 public:
 	FieldManipulator();
@@ -31,7 +39,8 @@ private:
 
 	// functions performing field manipulations
 	bool scale(Field *, Time *, int, double);
-	bool apply_SPP(Field *, Time *, int, double, int, double);
+	bool apply_SPP(Field *, Time *, FieldManipulator_SPP_Params &);
+	double apply_SPP_getphase(int, int, FieldManipulator_SPP_Params &);
 
 	// MPI related members
 	int rank_ {0};

--- a/include/FieldManipulator.h
+++ b/include/FieldManipulator.h
@@ -28,6 +28,14 @@ public:
 
 private:
 	void usage(void);
+
+	// functions performing field manipulations
+	bool scale(Field *, Time *, int, double);
+	bool apply_SPP(Field *, Time *, int, double, int, double);
+
+	// MPI related members
+	int rank_ {0};
+	int size_ {1};
 };
 
 #endif // __GENESIS_FIELDMANIPULATOR_H

--- a/src/Main/FieldManipulator.cpp
+++ b/src/Main/FieldManipulator.cpp
@@ -5,6 +5,8 @@
 #include <mpi.h>
 #include "FieldManipulator.h"
 
+#define DBG_SPP
+
 FieldManipulator::FieldManipulator() {
 	MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
 	MPI_Comm_size(MPI_COMM_WORLD, &size_);
@@ -170,6 +172,13 @@ bool FieldManipulator::apply_SPP(Field *p_fld, Time *time, int harm,
 				if ((dix!=0) || (diy!=0))
 					phi += atan2(diy,dix); // if both arguments to atan2 are zero this would give a 'domain error'
 				phi = spp_l*phi + spp_phi0;
+
+#ifdef DBG_SPP
+				// test case to check indexing and phase conventions
+				phi = 0;
+				if((dix<=0) && (diy<=0))
+					phi = 2.*atan(1.);
+#endif
 				
 				// apply phase factor to complex field in current grid cell
 				complex<double> phase_factor = polar(1., phi);

--- a/src/Main/FieldManipulator.cpp
+++ b/src/Main/FieldManipulator.cpp
@@ -15,8 +15,8 @@ FieldManipulator::~FieldManipulator() { }
 
 
 void FieldManipulator::usage(){
-  cout << "List of keywords for FIELD_MANIPULATOR" << endl;
-  cout << "&field_manipulator" << endl;
+  cout << "List of keywords for ALTER_FIELD" << endl;
+  cout << "&alter_field" << endl;
   cout << " int harm = 1" << endl;
   cout << " double scale_power = 1.0" << endl;
   cout << " double spp_l = 0.0" << endl;

--- a/src/Main/FieldManipulator.cpp
+++ b/src/Main/FieldManipulator.cpp
@@ -1,7 +1,14 @@
 #include <cmath>
+#include <cassert>
+#include <iostream>
+#include <fstream>
+#include <mpi.h>
 #include "FieldManipulator.h"
 
-FieldManipulator::FieldManipulator() { }
+FieldManipulator::FieldManipulator() {
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
+	MPI_Comm_size(MPI_COMM_WORLD, &size_);
+}
 FieldManipulator::~FieldManipulator() { }
 
 
@@ -10,6 +17,9 @@ void FieldManipulator::usage(){
   cout << "&field_manipulator" << endl;
   cout << " int harm = 1" << endl;
   cout << " double scale_power = 1.0" << endl;
+  cout << " double spp_l = 0.0" << endl;
+  cout << " int spp_nsect = 0" << endl;
+  cout << " double spp_phi0 = 0.0" << endl;
   cout << "&end" << endl << endl;
   return;
 }
@@ -18,11 +28,40 @@ bool FieldManipulator::init(int rank, int size, map<string,string> *arg, vector<
 {
 	map<string,string>::iterator end=arg->end();
 	int harm = 1;
+
 	double scale_P = 1.0;
+	bool do_scale = false;
+
+	double spp_l    = 0.0;
+	int spp_nsect   = 0;
+	double spp_phi0 = 0.0;
+	bool do_spp = false;
 
 	// extract parameters
 	if (arg->find("harm")!=end)         {harm    = atoi(arg->at("harm").c_str());        arg->erase(arg->find("harm"));}
-	if (arg->find("scale_power")!=end)  {scale_P = atof(arg->at("scale_power").c_str()); arg->erase(arg->find("scale_power"));}
+	if (arg->find("scale_power")!=end) {
+		do_scale = true; // specifying the parameter switches on code for scaling of the field
+		scale_P = atof(arg->at("scale_power").c_str());
+		arg->erase(arg->find("scale_power"));
+	}
+
+	if (arg->find("spp_nsect")!=end) {
+		do_spp = true; // specifying an SPP parameter switches the corresponding code block
+		spp_nsect = atoi(arg->at("spp_nsect").c_str());
+		arg->erase(arg->find("spp_nsect"));
+	}
+	if (arg->find("spp_l")!=end) {
+		do_spp = true; // specifying an SPP parameter switches the corresponding code block
+		spp_l = atof(arg->at("spp_l").c_str());
+		arg->erase(arg->find("spp_l"));
+	}
+	if (arg->find("spp_phi0")!=end) {
+		do_spp = true; // specifying an SPP parameter switches the corresponding code block
+		spp_phi0 = atof(arg->at("spp_phi0").c_str());
+		arg->erase(arg->find("spp_phi0"));
+	}
+
+
 
 	if (arg->size()!=0){
 		if (rank==0) {
@@ -65,8 +104,22 @@ bool FieldManipulator::init(int rank, int size, map<string,string> *arg, vector<
 	}
 
 
-	// *** process field ***
-	if(rank==0) {
+	/*** process field ***/
+	if(do_scale)
+		scale(p_fld, time, harm, scale_P);
+	if(do_spp)
+		apply_SPP(p_fld, time, harm, spp_l, spp_nsect, spp_phi0);
+
+	return(true);
+}
+
+/*****************************************************/
+/*** FUNCTIONS PERFORMING THE ACTUAL MANIPULATIONS ***/
+/*****************************************************/
+
+bool FieldManipulator::scale(Field *p_fld, Time *time, int harm, double scale_P)
+{
+	if(rank_==0) {
 		cout << "Scaling power in field harmonic=" << harm << " by factor " << scale_P << " ..." << endl;
 	}
 	int ngrid = p_fld->ngrid;
@@ -74,6 +127,61 @@ bool FieldManipulator::init(int rank, int size, map<string,string> *arg, vector<
 	for(int idslice=0; idslice < time->getNodeNSlice(); idslice++) {
 		for(int k=0; k<ngrid*ngrid; k++) {
 			p_fld->field[idslice].at(k) *= scale_field;
+		}
+	}
+	return(true);
+}
+
+
+bool FieldManipulator::apply_SPP(Field *p_fld, Time *time, int harm,
+	double spp_l, int spp_nsect, double spp_phi0)
+{
+	bool dbg_dump_phi=true;
+
+	if(rank_==0) {
+		cout << "Applying SPP to field harmonic=" << harm
+		     << ", parameters: spp_l=" << spp_l << ", spp_nsect=" << spp_nsect << ", spp_phi0=" << spp_phi0 << endl;
+	}
+
+	const int ngrid = p_fld->ngrid;
+
+	const int icenter = (ngrid-1)/2;
+	assert((ngrid%2)==1); // In GENESIS, ngrid is always odd. Just to be sure.
+
+	int iy, ix;
+	for(int idslice=0; idslice < time->getNodeNSlice(); idslice++) {
+		bool do_dump = dbg_dump_phi && (rank_==0) && (idslice==0);
+
+		ofstream ofs;
+
+		if(do_dump) {
+			ofs.open("dump_phi.txt", ofstream::out);
+		}
+
+		for(iy=0; iy<ngrid; iy++) {
+			for(ix=0; ix<ngrid; ix++) {
+				int idx = iy*ngrid+ix; // see for instance src/Core/Diagnostic.cpp, function 'DiagField::getTags' (commit id efcc090)
+				
+				int dix = ix-icenter;
+				int diy = iy-icenter;
+				
+				// determine SPP phase for current grid cell
+				double phi=0.;
+				if ((dix!=0) || (diy!=0))
+					phi += atan2(diy,dix); // if both arguments to atan2 are zero this would give a 'domain error'
+				phi = spp_l*phi + spp_phi0;
+				
+				// apply phase factor to complex field in current grid cell
+				complex<double> phase_factor = polar(1., phi);
+				p_fld->field[idslice].at(idx) *= phase_factor;
+
+				if(do_dump)
+					ofs << phi << " ";
+			}
+		}
+
+		if(do_dump) {
+			ofs.close();
 		}
 	}
 

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -263,11 +263,21 @@ int genmain (string mainstring, map<string,string> &comarg, bool split) {
           //----------------------------------------------------
           // field manipulation
 
-	      if (element.compare("&field_manipulator")==0){
-	        FieldManipulator *q = new FieldManipulator;
-            if (!q->init(rank,size,&argument,&field,setup,timewindow,profile)){ break;}
-	        delete q;
-            continue;  
+          bool do_alter_field=false;
+	  if (element.compare("&field_manipulator")==0) {
+	    do_alter_field=true;
+            if(0==rank) {
+              cout << "Warning: &field_manipulator is deprecated and will be removed in the future. Use &alter_field instead." << endl;
+	    }
+	  }
+	  if (element.compare("&alter_field")==0) {
+	    do_alter_field=true;
+	  }
+	  if(do_alter_field) {
+	    FieldManipulator *q = new FieldManipulator;
+	    if (!q->init(rank,size,&argument,&field,setup,timewindow,profile)){ break;}
+	    delete q;
+	    continue;  
           }  
 	 
           //----------------------------------------------------


### PR DESCRIPTION
Spiral phase plate (SPP) introduces phase shift of electric field, depending on transverse position.

Parameters: `spp_l`, `spp_phi0`, `spp_nsect`. Specifying any of these parameters activates the SPP code block.

## Update 2023-09-04
Added new namelist `&alter_field` that will eventually replace `&field_manipulator`. As of now, `&field_manipulator` can still be used and the message
```Warning: &field_manipulator is deprecated and will be removed in the future. Use &alter_field instead.```
is displayed.