### PR TITLE
some error handling for field/beam dumping

### DIFF
--- a/include/writeBeamHDF5.h
+++ b/include/writeBeamHDF5.h
@@ -20,7 +20,7 @@ class WriteBeamHDF5 : public HDF5Base {
  public:
   WriteBeamHDF5();
   virtual ~WriteBeamHDF5();
-  void write(string, Beam *);
+  bool write(string, Beam *);
  
 
  private:

--- a/include/writeFieldHDF5.h
+++ b/include/writeFieldHDF5.h
@@ -24,11 +24,11 @@ class WriteFieldHDF5 : public HDF5Base {
  public:
   WriteFieldHDF5();
   virtual ~WriteFieldHDF5();
-  void write(string fileroot, vector<Field *> *field);
+  bool write(string fileroot, vector<Field *> *field);
 
 
  private:
-  void writeMain(string fileroot, Field *field);
+  bool writeMain(string fileroot, Field *field);
   void writeGlobal(double, double, double, double, int, int);
   void writeBufferD(hid_t, string, string, vector<double> *, vector<hsize_t> *, vector<hsize_t> *);
   hid_t fid;

--- a/src/IO/writeBeamHDF5.cpp
+++ b/src/IO/writeBeamHDF5.cpp
@@ -7,16 +7,11 @@ extern bool MPISingle;
 #define SLICESELECT_IGNORE  0
 
 // constructor destructor
-WriteBeamHDF5::WriteBeamHDF5()
-{
-}
-
-WriteBeamHDF5::~WriteBeamHDF5()
-{
-}
+WriteBeamHDF5::WriteBeamHDF5()  {}
+WriteBeamHDF5::~WriteBeamHDF5() {}
 
 
-void WriteBeamHDF5::write(string fileroot, Beam *beam)
+bool WriteBeamHDF5::write(string fileroot, Beam *beam)
 {
   MPI_Comm_rank(MPI_COMM_WORLD, &rank); // assign rank to node
   MPI_Comm_size(MPI_COMM_WORLD, &size); // assign rank to node
@@ -25,23 +20,12 @@ void WriteBeamHDF5::write(string fileroot, Beam *beam)
     rank=0;
   }
 
-#if 0
-  char filename[100];
-  sprintf(filename,"%s.par.h5",fileroot.c_str()); 
-  if (rank == 0) { cout << "Writing particle distribution to file: " <<filename << " ..." << endl;} 
-
-  hid_t pid = H5Pcreate(H5P_FILE_ACCESS);
-  if (size>1){
-    H5Pset_fapl_mpio(pid,MPI_COMM_WORLD,MPI_INFO_NULL);
-  }
-  fid=H5Fcreate(filename,H5F_ACC_TRUNC, H5P_DEFAULT,pid); 
-  H5Pclose(pid);
-#else
   string filename;
   filename = fileroot+".par.h5";
   if (rank == 0) { cout << "Writing particle distribution to file: " <<filename << " ..." << endl;} 
-  create_outfile(&fid, filename);
-#endif
+  if(!create_outfile(&fid, filename)) {
+    return(false);
+  }
 
   s0=rank;
   int ntotal=size*beam->beam.size();
@@ -150,7 +134,7 @@ void WriteBeamHDF5::write(string fileroot, Beam *beam)
     }
   }
 
-  return;
+  return(true);
 }
 
 // void WriteBeamHDF5::writeGlobal(int nbins,bool one4one, double reflen, double slicelen, double s0, int count)

--- a/src/Main/Dump.cpp
+++ b/src/Main/Dump.cpp
@@ -47,7 +47,12 @@ bool Dump::init(int inrank, int insize, map<string,string> *arg, Setup *setup, B
 
    string completefn;
    setup->RootName_to_FileName(&completefn, &dumpbeam);
-   dump.write(completefn,beam);
+   if(!dump.write(completefn,beam)) {
+     if(inrank==0) {
+       cout << "   write operation was not successful!" << endl;
+     }
+     return(false);
+   }
   }
 
   return(true);

--- a/src/Main/Dump.cpp
+++ b/src/Main/Dump.cpp
@@ -24,7 +24,7 @@ bool Dump::init(int inrank, int insize, map<string,string> *arg, Setup *setup, B
   if (arg->find("beam")!=end) {dumpbeam =arg->at("beam");  arg->erase(arg->find("beam"));}
   if (arg->size()!=0){
     if (inrank==0){ cout << "*** Error: Unknown elements in &write" << endl; this->usage();}
-    return false;
+    return(false);
   }
 
   
@@ -32,7 +32,12 @@ bool Dump::init(int inrank, int insize, map<string,string> *arg, Setup *setup, B
    WriteFieldHDF5 dump;
    string completefn;
    setup->RootName_to_FileName(&completefn, &dumpfield);
-   dump.write(completefn,field);
+   if(!dump.write(completefn,field)) {
+     if(inrank==0) {
+       cout << "   write operation was not successful!" << endl;
+     }
+     return(false);
+   }
   }
   if (dumpbeam.size()>0){
    WriteBeamHDF5 dump;
@@ -45,5 +50,5 @@ bool Dump::init(int inrank, int insize, map<string,string> *arg, Setup *setup, B
    dump.write(completefn,beam);
   }
 
-  return true;
+  return(true);
 }


### PR DESCRIPTION
If the file cannot be created the field/beam dump operation aborts. This catches already lots of issues, however, IO errors after opening the file for write still require additional handling.