### PR TITLE
various small enhancements

### DIFF
--- a/include/Control.h
+++ b/include/Control.h
@@ -23,8 +23,8 @@ class Control : public HDF5Base{
    virtual ~Control();
    void applySlippage(double, Field *);
    bool applyMarker(Beam *, vector<Field *> *, Undulator *, bool&);
-   bool init(int, int, const char *, Beam *, vector<Field *> *, Undulator *,bool,bool);
-   void output(Beam *, vector<Field*> *,Undulator *,Diagnostic &);
+   bool init(int, int, const std::string, Beam *, vector<Field *> *, Undulator *,bool,bool);
+   // void output(Beam *, vector<Field*> *,Undulator *,Diagnostic &);
 
  private:
    bool timerun,scanrun,one4one;

--- a/include/Diagnostic.h
+++ b/include/Diagnostic.h
@@ -90,12 +90,13 @@ class Diagnostic{
 
 
 public:
-    Diagnostic() = default;
+    Diagnostic();
     // virtual ~Diagnostic() = default;
     virtual ~Diagnostic();
     void init(int,int, int, int,int,bool,bool, FilterDiagnostics &);
     void calc(Beam *, std::vector<Field*> *,double);
-    void writeToOutputFile(std::string, std::string, Beam *, vector<Field*> *, Undulator *, bool);
+    bool writeToOutputFile(std::string, std::string, Beam *, vector<Field*> *, Undulator *, bool);
+
     std::vector<std::map<std::string,std::vector<double> > > val;
     std::vector<std::map<std::string,std::string > >units;
     std::vector<std::map<std::string, bool> > single;
@@ -110,6 +111,8 @@ private:
     bool time,scan;
 
     bool diag_can_add {true};
+
+    int my_rank_;
 };
 
 

--- a/include/Diagnostic.h
+++ b/include/Diagnostic.h
@@ -17,14 +17,19 @@
 #include "FFTObj.h"
 #endif
 
-#include "Field.h"
-#include "Beam.h"
-#include "Undulator.h"
+//#include "Field.h"
+//#include "Beam.h"
+//#include "Undulator.h"
+class Beam;
+class Field;
+class Undulator;
+class Setup;
 
 #include "DiagnosticBase.h"
 #ifdef USE_DPI
   #include "DiagnosticHook.h"
 #endif
+
 
 //------------------------------------
 // genesis official class for beam diagnostics
@@ -95,7 +100,7 @@ public:
     virtual ~Diagnostic();
     void init(int,int, int, int,int,bool,bool, FilterDiagnostics &);
     void calc(Beam *, std::vector<Field*> *,double);
-    bool writeToOutputFile(std::string, std::string, Beam *, vector<Field*> *, Undulator *, bool);
+    bool writeToOutputFile(Beam *, vector<Field*> *, Setup *, Undulator *);
 
     std::vector<std::map<std::string,std::vector<double> > > val;
     std::vector<std::map<std::string,std::string > >units;

--- a/include/Diagnostic.h
+++ b/include/Diagnostic.h
@@ -95,7 +95,7 @@ public:
     virtual ~Diagnostic();
     void init(int,int, int, int,int,bool,bool, FilterDiagnostics &);
     void calc(Beam *, std::vector<Field*> *,double);
-    void writeToOutputFile(std:: string, Beam *, vector<Field*> *, Undulator *);
+    void writeToOutputFile(std::string, std::string, Beam *, vector<Field*> *, Undulator *, bool);
     std::vector<std::map<std::string,std::vector<double> > > val;
     std::vector<std::map<std::string,std::string > >units;
     std::vector<std::map<std::string, bool> > single;

--- a/include/DiagnosticHook.h
+++ b/include/DiagnosticHook.h
@@ -31,6 +31,7 @@ public:
 	void close_lib(void);
 	bool is_libok(void);
 	bool supports_multimode(void);
+	const std::string& get_info_txt() const;
 
 	DiagFieldHookedBase *pdiagfield_ {nullptr};
 	DiagBeamHookedBase  *pdiagbeam_ {nullptr};
@@ -58,6 +59,7 @@ private:
 	fptr_db beamdiag_destroyer_ {nullptr};
 	bool is_field_ {true};
 	bool multimode_ {false};
+	std::string info_txt_;
 	
 	int my_rank_, comm_size_;
 };
@@ -74,6 +76,7 @@ public:
 
 	bool init(DiagBeamPluginCfg *);
 	void set_runid(int);
+	const std::string& get_info_txt() const;
 
 private:
 	bool update_data(std::map<std::string,std::vector<double> > &, std::string, size_t, double);
@@ -102,6 +105,7 @@ public:
 
 	bool init(DiagFieldPluginCfg *);
 	void set_runid(int);
+	const std::string& get_info_txt() const;
 
 private:
 	bool update_data(std::map<std::string,std::vector<double> > &, std::string, size_t, double);

--- a/include/DiagnosticHook.h
+++ b/include/DiagnosticHook.h
@@ -30,6 +30,8 @@ public:
 	bool init_lib(std::string);
 	void close_lib(void);
 	bool is_libok(void);
+	bool is_plugintype_field(void);
+	bool is_plugintype_beam(void);
 	bool supports_multimode(void);
 	const std::string& get_info_txt() const;
 

--- a/include/Gencore.h
+++ b/include/Gencore.h
@@ -30,7 +30,7 @@ class Gencore{
  public:
   Gencore(){};
   virtual ~Gencore(){};
-  bool run(const char *,Beam *, vector<Field *> *, Setup *, Undulator *, bool, bool, FilterDiagnostics &filter);
+  bool run(Beam *, vector<Field *> *, Setup *, Undulator *, bool, bool, FilterDiagnostics &filter);
 };
 
 

--- a/include/Output.h
+++ b/include/Output.h
@@ -33,9 +33,11 @@ class Output : public HDF5Base {
    void writeLattice(Beam *, Undulator *);
    void writeGlobal(Undulator *,double,double,double,double,bool,bool,bool,int);
    void writeMeta(Undulator *);
+   void writeMetaWorker(Undulator *, hid_t);
    void writeGroup(std::string group,std::map<std::string,std::vector<double> >&, std::map<std::string,std::string> &, std::map<std::string,bool> &);
    void writeDataset(hid_t,std::string, std::vector<double> &, string, bool);
    void reportDumps(hid_t, Undulator *);
+   void reportPlugins(hid_t, Undulator *);
    void reportMPI(hid_t);
 
  private:

--- a/include/Output.h
+++ b/include/Output.h
@@ -26,7 +26,7 @@ class Output : public HDF5Base {
  public:
    Output();
    virtual ~Output();
-   void open(string,int,int);
+   bool open(string,int,int);
    void close();
    void writeFieldBuffer(Field *);
    void writeBeamBuffer(Beam *);

--- a/include/Setup.h
+++ b/include/Setup.h
@@ -49,6 +49,7 @@ class Setup: public StringProcessing{
    bool   getSemaEnDone();
    void   setSemaFN(string);
    bool   getSemaFN(string *);
+   bool   get_write_meta_file();
 
    int    getNpart();
    int    getNbins();
@@ -91,6 +92,7 @@ class Setup: public StringProcessing{
 
    int seed, rank,npart,nbins,runcount;
 
+   bool write_meta_file;
    bool sema_file_enabled_start, sema_file_enabled_done;
    string sema_file_name; // user-defined name of semaphore file, if empty: file name will be derived in function getSemaFN
 };
@@ -141,4 +143,6 @@ inline void   Setup::BWF_set_inc(int in)
 
 inline bool   Setup::getSemaEnStart() { return sema_file_enabled_start; }
 inline bool   Setup::getSemaEnDone()  { return sema_file_enabled_done; }
+
+inline bool   Setup::get_write_meta_file(){ return write_meta_file;}
 #endif

--- a/include/Setup.h
+++ b/include/Setup.h
@@ -50,6 +50,8 @@ class Setup: public StringProcessing{
    void   setSemaFN(string);
    bool   getSemaFN(string *);
    bool   get_write_meta_file();
+   void   set_do_write_outfile(bool);
+   bool   get_do_write_outfile();
 
    int    getNpart();
    int    getNbins();
@@ -86,6 +88,7 @@ class Setup: public StringProcessing{
    bool one4one,shotnoise;
    bool beam_global_stat, field_global_stat;
    bool exclude_spatial_output, exclude_fft_output, exclude_intensity_output, exclude_energy_output, exclude_aux_output, exclude_current_output, exclude_field_dump;
+   bool do_write_outfile;
 
    bool beam_write_filter;
    int beam_write_slices_from, beam_write_slices_to, beam_write_slices_inc;
@@ -120,6 +123,8 @@ inline bool   Setup::outputEnergy(){ return exclude_energy_output;}
 inline bool   Setup::outputCurrent(){ return exclude_current_output;}
 inline bool   Setup::outputAux(){ return exclude_aux_output;}
 inline bool   Setup::outputFieldDump() { return exclude_field_dump;}
+inline void   Setup::set_do_write_outfile(bool v) {do_write_outfile=v;}
+inline bool   Setup::get_do_write_outfile()       {return do_write_outfile;}
 
 inline bool   Setup::BWF_get_enabled()    { return beam_write_filter; }
 inline void   Setup::BWF_set_enabled(bool in) { beam_write_filter=in; }

--- a/include/Undulator.h
+++ b/include/Undulator.h
@@ -59,7 +59,7 @@ class Undulator: public HDF5Base{
    vector<double> qf,qx,qy,z,dz,slip,phaseshift; 
    vector<double> chic_angle,chic_lb,chic_ld,chic_lt; 
    vector<double> paw,pkx,pky,pgradx,pgrady,pphase; // perpendicular undulator parameters
-   vector<int> helical,marker;
+   vector<int>    helical,marker;
 
    vector<string> fielddumps_filename;
    vector<int>    fielddumps_intstep;

--- a/include/Undulator.h
+++ b/include/Undulator.h
@@ -66,6 +66,10 @@ class Undulator: public HDF5Base{
    vector<string> beamdumps_filename;
    vector<int>    beamdumps_intstep;
 
+   // for plugin interface: used to retain information obtained at the beginning of tracking run for later storage in .out.h5 file (class instance is provided to output::writeMeta) 
+   vector<string> plugin_info_txt;
+   vector<string> plugin_hdf5_prefix;
+
 
  private: 
 

--- a/src/Core/Control.cpp
+++ b/src/Core/Control.cpp
@@ -81,10 +81,9 @@ bool Control::applyMarker(Beam *beam, vector<Field*>*field, Undulator *und, bool
 }
 
 
+#if 0 // .out.h5 file is now written in class Diagnostic
 void Control::output(Beam *beam, vector<Field*> *field, Undulator *und, Diagnostic &diag)
 {
-
-  
   Output *out=new Output;
 
   string file=root.append(".out.h5");
@@ -102,21 +101,15 @@ void Control::output(Beam *beam, vector<Field*> *field, Undulator *und, Diagnost
  
   delete out;
   return;
-
-
-
 }
+#endif
 
 
-bool Control::init(int inrank, int insize, const char *file, Beam *beam, vector<Field*> *field, Undulator *und, bool inTime, bool inScan)
+bool Control::init(int inrank, int insize, const string in_rootname, Beam *beam, vector<Field*> *field, Undulator *und, bool inTime, bool inScan)
 {
-
   rank=inrank;
   size=insize;
-
-  stringstream sroot(file);
-  root=sroot.str();
-  root.resize(root.size()-7);  // remove the extension ".h5"
+  root = in_rootname;
 
   one4one=beam->one4one;
   reflen=beam->reflength;

--- a/src/Core/Diagnostic.cpp
+++ b/src/Core/Diagnostic.cpp
@@ -189,6 +189,7 @@ bool Diagnostic::writeToOutputFile(string fnout, string fnmeta, Beam *beam, vect
     this->addOutput(1,"frequency","ev",global);
 
 
+
     Output *out=new Output;
 //    string file=root.append(".test"); // CL, 2023-10-16: variable 'root' was renamed
     if(!out->open(fnout,noff,ns)) {
@@ -198,8 +199,6 @@ bool Diagnostic::writeToOutputFile(string fnout, string fnmeta, Beam *beam, vect
       delete out;
       return(false);
     }
-
-
     out->writeMeta(und);
     out->writeGroup("Lattice",val[0], units[0],single[0]);
     out->writeGroup("Global",val[1], units[1],single[1]);
@@ -216,11 +215,18 @@ bool Diagnostic::writeToOutputFile(string fnout, string fnmeta, Beam *beam, vect
     delete out;
 
 
-    if(write_meta_file) {
+    if(write_meta_file)
+    {
         Output out_meta;
-        out_meta.open(fnmeta,
-            noff /* controls which node is writing the strings to the hdf5 file */,
-            ns);
+        if(!out_meta.open(fnmeta,
+               noff /* controls which node is writing the strings to the hdf5 file */,
+               ns))
+        {
+            if(my_rank_==0) {
+                cout << "   unable to open output file" << endl;
+            }
+            return(false);
+        }
         out_meta.writeMeta(und);
         out_meta.close();
     }

--- a/src/Core/Diagnostic.cpp
+++ b/src/Core/Diagnostic.cpp
@@ -128,13 +128,11 @@ void Diagnostic::addOutput(int groupID, std::string key, std::string unit, std::
 }
 
 // adds some output and lfushes everything to a file
-void Diagnostic::writeToOutputFile(std::string root, Beam *beam, vector<Field*> *field, Undulator *und)
+void Diagnostic::writeToOutputFile(string fnout, string fnmeta, Beam *beam, vector<Field*> *field, Undulator *und, bool write_meta_file)
 {
     // lock the vectors holding the instances of diagnostic classes
     diag_can_add=false;
 
-    Output *out=new Output;
-//    string file=root.append(".test");
     this->addOutput(0,"zplot","m", zout);
     this->addOutput(0,"z","m", und->z);
     this->addOutput(0,"dz","m", und->dz);
@@ -189,7 +187,13 @@ void Diagnostic::writeToOutputFile(std::string root, Beam *beam, vector<Field*> 
     }
     this->addOutput(1,"frequency","ev",global);
 
-    out->open(root,noff,ns);
+
+
+
+
+    Output *out=new Output;
+//    string file=root.append(".test");
+    out->open(fnout,noff,ns);
     out->writeMeta(und);
     out->writeGroup("Lattice",val[0], units[0],single[0]);
     out->writeGroup("Global",val[1], units[1],single[1]);
@@ -204,7 +208,15 @@ void Diagnostic::writeToOutputFile(std::string root, Beam *beam, vector<Field*> 
     }
     out->close();
     delete out;
-    return;
+
+    if(write_meta_file) {
+        Output out_meta;
+        out_meta.open(fnmeta,
+            noff /* controls which node is writing the strings to the hdf5 file */,
+            ns);
+        out_meta.writeMeta(und);
+        out_meta.close();
+    }
 }
 
 // wrapper to do all the diagnostics calculation at a given integration step iz.

--- a/src/Core/Diagnostic.cpp
+++ b/src/Core/Diagnostic.cpp
@@ -3,11 +3,13 @@
 //
 
 #include <iostream>
+#include <sstream>
 #include <complex>
 #include <mpi.h>
 
 #include "Diagnostic.h"
 #include "Output.h"
+#include "Setup.h"
 
 Diagnostic::Diagnostic()
 {
@@ -82,7 +84,7 @@ void Diagnostic::init(int rank, int size, int nz_in, int ns_in, int nfld,bool is
 
     // loop through the different class for registration and allocate memory
 
-    // undulator group (val.at(0) will be defined later in this->writeOutputFile
+    // undulator group (val.at(0) will be defined later in this->writeToOutputFile
 
     // beam
     for (auto group : dbeam){
@@ -129,10 +131,21 @@ void Diagnostic::addOutput(int groupID, std::string key, std::string unit, std::
 }
 
 // adds some output and flushes everything to a file
-bool Diagnostic::writeToOutputFile(string fnout, string fnmeta, Beam *beam, vector<Field*> *field, Undulator *und, bool write_meta_file)
+bool Diagnostic::writeToOutputFile(Beam *beam, vector<Field*> *field, Setup *setup, Undulator *und)
 {
     // lock the vectors holding the instances of diagnostic classes
     diag_can_add=false;
+
+    string rn, fnout;
+    setup->getRootName(&rn);
+    setup->RootName_to_FileName(&fnout, &rn);
+    fnout.append(".out.h5");
+
+    // generate file name for optional file with copy of metadata (this is a copy of the corresponding code block in Track.cpp)
+    string fnmeta;
+    setup->RootName_to_FileName(&fnmeta, &rn);
+    fnmeta.append(".meta.h5");
+
 
     this->addOutput(0,"zplot","m", zout);
     this->addOutput(0,"z","m", und->z);
@@ -190,32 +203,43 @@ bool Diagnostic::writeToOutputFile(string fnout, string fnmeta, Beam *beam, vect
 
 
 
-    Output *out=new Output;
+    if(setup->get_do_write_outfile())
+    {
+        Output out;
 //    string file=root.append(".test"); // CL, 2023-10-16: variable 'root' was renamed
-    if(!out->open(fnout,noff,ns)) {
-      if(my_rank_==0) {
-        cout << "   unable to open output file" << endl;
-      }
-      delete out;
-      return(false);
-    }
-    out->writeMeta(und);
-    out->writeGroup("Lattice",val[0], units[0],single[0]);
-    out->writeGroup("Global",val[1], units[1],single[1]);
-    out->writeGroup("Beam",val[2], units[2],single[2]);
-    for (int i=3; i<val.size();i++){
-        const int h = field->at(i-3)->harm;
-        char objname[30] = "Field"; // default for harmonic==1
-        if (h!=1){
-            snprintf(objname, sizeof(objname), "Field%d", h);
+        if(!out.open(fnout,noff,ns)) {
+          if(my_rank_==0) {
+            cout << "   unable to open output file" << endl;
+          }
+          return(false);
         }
-        out->writeGroup(objname,val[i], units[i],single[i]);
+        out.writeMeta(und);
+        out.writeGroup("Lattice",val[0], units[0],single[0]);
+        out.writeGroup("Global",val[1], units[1],single[1]);
+        out.writeGroup("Beam",val[2], units[2],single[2]);
+        for (int i=3; i<val.size();i++){
+            const int h = field->at(i-3)->harm;
+            char objname[30] = "Field"; // default for harmonic==1
+            if (h!=1){
+                snprintf(objname, sizeof(objname), "Field%d", h);
+            }
+            out.writeGroup(objname,val[i], units[i],single[i]);
+        }
+        out.close();
+    } else {
+       /* debug option to suppress .out.h5 file is ON: generate info file instead */
+       if(my_rank_==0) {
+           stringstream ss;
+           ofstream ofs;
+           ss << fnout << ".suppressed";
+           ofs.open(ss.str(), ofstream::out);
+           ofs.close();
+           cout << "   INFO: debug option to suppress writing of .out.h5 file is set" << endl;
+       }
     }
-    out->close();
-    delete out;
 
 
-    if(write_meta_file)
+    if(setup->get_write_meta_file())
     {
         Output out_meta;
         if(!out_meta.open(fnmeta,

--- a/src/Core/Diagnostic.cpp
+++ b/src/Core/Diagnostic.cpp
@@ -195,14 +195,12 @@ void Diagnostic::writeToOutputFile(std::string root, Beam *beam, vector<Field*> 
     out->writeGroup("Global",val[1], units[1],single[1]);
     out->writeGroup("Beam",val[2], units[2],single[2]);
     for (int i=3; i<val.size();i++){
-        int h=field->at(i-3)->harm;
-        if (h==1){
-            out->writeGroup("Field",val[i], units[i],single[i]);
-        } else {
-            char buff[30];
-            snprintf(buff, sizeof(buff), "Field%d", h);
-            out->writeGroup(buff,val[i], units[i],single[i]);
+        const int h = field->at(i-3)->harm;
+        char objname[30] = "Field"; // default for harmonic==1
+        if (h!=1){
+            snprintf(objname, sizeof(objname), "Field%d", h);
         }
+        out->writeGroup(objname,val[i], units[i],single[i]);
     }
     out->close();
     delete out;

--- a/src/Core/DiagnosticHook.cpp
+++ b/src/Core/DiagnosticHook.cpp
@@ -47,7 +47,12 @@ bool DiagFieldHook::init(DiagFieldPluginCfg *pin)
 	lib_verbose_       = pin->lib_verbose;
 	interface_verbose_ = pin->interface_verbose;
 	
-	return(li_.init_lib(pin->libfile));
+	bool res_init = li_.init_lib(pin->libfile);
+	bool is_field = li_.is_plugintype_field(); // current implementation of function signals false if load was unsuccessful
+	if((!is_field) && (my_rank_==0)) {
+		cout << "ERROR: This appears not to be a field plugin" << endl;
+	}
+	return(res_init && is_field);
 }
 
 void DiagFieldHook::set_runid(int runid_in)

--- a/src/Core/DiagnosticHook.cpp
+++ b/src/Core/DiagnosticHook.cpp
@@ -54,6 +54,10 @@ void DiagFieldHook::set_runid(int runid_in)
 {
 	runid_ = runid_in;
 }
+const std::string& DiagFieldHook::get_info_txt() const
+{
+	return(li_.get_info_txt());
+}
 
 bool DiagFieldHook::update_data(std::map<std::string,std::vector<double> > &val, string key, size_t idx, double v)
 {

--- a/src/Core/DiagnosticHookBeam.cpp
+++ b/src/Core/DiagnosticHookBeam.cpp
@@ -54,6 +54,10 @@ void DiagBeamHook::set_runid(int runid_in)
 {
 	runid_ = runid_in;
 }
+const std::string& DiagBeamHook::get_info_txt() const
+{
+	return(li_.get_info_txt());
+}
 
 bool DiagBeamHook::update_data(std::map<std::string,std::vector<double> > &val, string key, size_t idx, double v)
 {

--- a/src/Core/DiagnosticHookBeam.cpp
+++ b/src/Core/DiagnosticHookBeam.cpp
@@ -33,7 +33,7 @@ bool DiagBeamHook::init(DiagBeamPluginCfg *pin)
 	if(my_rank_==0) {
 		cout << "DiagBeamHook::init" << endl;
 	}
-#if 1
+
 	/* Copy all needed infos from the configuration data */
 	// li_.libfile_           = pin->libfile;
 	//li_.obj_prefix_        = pin->obj_prefix;
@@ -46,8 +46,12 @@ bool DiagBeamHook::init(DiagBeamPluginCfg *pin)
 	lib_verbose_       = pin->lib_verbose;
 	interface_verbose_ = pin->interface_verbose;
 	
-	return(li_.init_lib(pin->libfile));
-#endif
+	bool res_init = li_.init_lib(pin->libfile);
+	bool is_beam  = li_.is_plugintype_beam(); // current implementation of function signals false if load was unsuccessful
+	if((!is_beam) && (my_rank_==0)) {
+		cout << "ERROR: This appears not to be a beam plugin" << endl;
+	}
+	return(res_init && is_beam);
 }
 
 void DiagBeamHook::set_runid(int runid_in)

--- a/src/Core/DiagnosticHookLI.cpp
+++ b/src/Core/DiagnosticHookLI.cpp
@@ -299,6 +299,22 @@ bool LibraryInterface::is_libok(void)
 {
 	return(libok_);
 }
+bool LibraryInterface::is_plugintype_field(void)
+{
+	// if library is not OK, we don't know if it is of field type (consider changing this if needed)
+	if(!libok_)
+		return(false);
+
+	return(is_field_);
+}
+bool LibraryInterface::is_plugintype_beam(void)
+{
+	// if library is not OK, we don't know if it is of field type (consider changing this if needed)
+	if(!libok_)
+		return(false);
+
+	return(!is_field_); // currently there are only two types of plugins: field and beam
+}
 
 const string& LibraryInterface::get_info_txt() const
 {

--- a/src/Core/DiagnosticHookLI.cpp
+++ b/src/Core/DiagnosticHookLI.cpp
@@ -237,7 +237,10 @@ bool LibraryInterface::get_shared_lib_objs(h_dynamic_lib *h)
 			cout << "Rank 0: Calling get_infos" << endl;
 		}
 		pdiagfield_->get_infos(&infos);
+
+		// store and report library infos
 		multimode_ = infos.do_multi;
+		info_txt_ = infos.info_txt;
 		clone_obj_names(infos.obj_names);
 		if(my_rank_==0) {
 			report_infos(&infos);
@@ -252,7 +255,10 @@ bool LibraryInterface::get_shared_lib_objs(h_dynamic_lib *h)
 			cout << "Rank 0: Calling get_infos" << endl;
 		}
 		pdiagbeam_->get_infos(&infos);
+
+		// store and report library infos
 		multimode_ = infos.do_multi;
+		info_txt_ = infos.info_txt;
 		clone_obj_names(infos.obj_names);
 		if(my_rank_==0) {
 			report_infos(&infos);
@@ -292,4 +298,9 @@ bool LibraryInterface::supports_multimode(void)
 bool LibraryInterface::is_libok(void)
 {
 	return(libok_);
+}
+
+const string& LibraryInterface::get_info_txt() const
+{
+	return(info_txt_);
 }

--- a/src/Core/Gencore.cpp
+++ b/src/Core/Gencore.cpp
@@ -6,7 +6,7 @@
 
 extern bool MPISingle;
 
-bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *setup, Undulator *und,bool isTime, bool isScan, FilterDiagnostics &filter)
+bool Gencore::run(Beam *beam, vector<Field*> *field, Setup *setup, Undulator *und,bool isTime, bool isScan, FilterDiagnostics &filter)
 {
     // function returns 'true' if everything is ok
 
@@ -28,8 +28,11 @@ bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *se
     //-----------------------------------------
 	// init beam, field and undulator class
 
+    string rn, fnbase;
+    setup->getRootName(&rn);
+    setup->RootName_to_FileName(&fnbase, &rn); // includes .RunX. if not the first &track command
     Control   *control=new Control;
-    control->init(rank,size,file,beam,field,und,isTime,isScan);
+    control->init(rank,size,fnbase,beam,field,und,isTime,isScan);
 
     Diagnostic diag;
 #ifdef USE_DPI
@@ -180,14 +183,8 @@ bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *se
 	  cout << "Writing output file..." << endl;
 	}
 
-	// generate file name for optional file with copy of metadata (this is a copy of the corresponding code block in Track.cpp)
-	string rn, fnout_meta;
-	setup->getRootName(&rn);
-	setup->RootName_to_FileName(&fnout_meta, &rn);
-	fnout_meta.append(".meta.h5");
-
 	// control->output(beam,field,und,diag);
-	if(!diag.writeToOutputFile(file, fnout_meta, beam,field,und, setup->get_write_meta_file())) {
+	if(!diag.writeToOutputFile(beam, field, setup, und)) {
 	  delete control;
 	  return(false);
 	}

--- a/src/Core/Gencore.cpp
+++ b/src/Core/Gencore.cpp
@@ -8,6 +8,7 @@ extern bool MPISingle;
 
 bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *setup, Undulator *und,bool isTime, bool isScan, FilterDiagnostics &filter)
 {
+    // function returns 'true' if everything is ok
 
 
     //-------------------------------------------------------
@@ -20,7 +21,7 @@ bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *se
 	    MPI_Comm_size(MPI_COMM_WORLD, &size); // assign rank to node
     }
 
-	if (rank==0) {
+    if (rank==0) {
         cout << endl << "Running Core Simulation..." << endl;
     }
 
@@ -185,8 +186,11 @@ bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *se
 	setup->RootName_to_FileName(&fnout_meta, &rn);
 	fnout_meta.append(".meta.h5");
 
-	diag.writeToOutputFile(file, fnout_meta, beam,field,und, setup->get_write_meta_file());
-    // control->output(beam,field,und,diag);
+	// control->output(beam,field,und,diag);
+	if(!diag.writeToOutputFile(file, fnout_meta, beam,field,und, setup->get_write_meta_file())) {
+	  delete control;
+	  return(false);
+	}
 
 	delete control;
       

--- a/src/Core/Gencore.cpp
+++ b/src/Core/Gencore.cpp
@@ -174,13 +174,18 @@ bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *se
 	}
 
 
-	// write out diagnostic arrays
-
+	/* write out diagnostic arrays */
 	if (rank==0){
 	  cout << "Writing output file..." << endl;
 	}
 
-	diag.writeToOutputFile(file, beam,field,und);
+	// generate file name for optional file with copy of metadata (this is a copy of the corresponding code block in Track.cpp)
+	string rn, fnout_meta;
+	setup->getRootName(&rn);
+	setup->RootName_to_FileName(&fnout_meta, &rn);
+	fnout_meta.append(".meta.h5");
+
+	diag.writeToOutputFile(file, fnout_meta, beam,field,und, setup->get_write_meta_file());
     // control->output(beam,field,und,diag);
 
 	delete control;

--- a/src/Core/Gencore.cpp
+++ b/src/Core/Gencore.cpp
@@ -38,8 +38,12 @@ bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *se
         }
         DiagFieldHook *pdfh = new DiagFieldHook(); /* !do not delete this instance, it will be destroyed when DiagFieldHook instance is deleted! */
         bool diaghook_ok = pdfh->init(&setup->diagpluginfield_.at(kk));
-	pdfh->set_runid(setup->getCount()); // propagate run id so that it can be used in the plugins, for instance for filename generation
         if(diaghook_ok) {
+	    pdfh->set_runid(setup->getCount()); // propagate run id so that it can be used in the plugins, for instance for filename generation
+	    string xx = pdfh->get_info_txt();
+	    if(rank==0) {
+	        cout << "info_txt: " << xx << endl;
+	    }
             diag.add_field_diag(pdfh);
             if(rank==0) {
                 cout << "DONE: Registered DiagFieldHook" << endl;
@@ -58,8 +62,12 @@ bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *se
 		}
 		DiagBeamHook *pdbh = new DiagBeamHook(); /* !do not delete this instance, it will be destroyed when DiagBeamHook instance is deleted! */
 		bool diaghook_ok = pdbh->init(&setup->diagpluginbeam_.at(kk));
-		pdbh->set_runid(setup->getCount()); // propagate run id so that it can be used in the plugins, for instance for filename generation
 		if(diaghook_ok) {
+			pdbh->set_runid(setup->getCount()); // propagate run id so that it can be used in the plugins, for instance for filename generation
+			string xx = pdbh->get_info_txt();
+			if(rank==0) {
+				cout << "info_txt: " << xx << endl;
+			}
 			diag.add_beam_diag(pdbh);
 			if(rank==0) {
 				cout << "DONE: Registered DiagBeamHook" << endl;

--- a/src/Core/Gencore.cpp
+++ b/src/Core/Gencore.cpp
@@ -32,6 +32,8 @@ bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *se
 
     Diagnostic diag;
 #ifdef USE_DPI
+    und->plugin_info_txt.clear();
+
     for(int kk=0; kk<setup->diagpluginfield_.size(); kk++) {
 	if(rank==0) {
             cout << "Setting up DiagFieldHook for libfile=\"" << setup->diagpluginfield_.at(kk).libfile << "\", obj_prefix=\"" << setup->diagpluginfield_.at(kk).obj_prefix << "\"" << endl;
@@ -40,10 +42,13 @@ bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *se
         bool diaghook_ok = pdfh->init(&setup->diagpluginfield_.at(kk));
         if(diaghook_ok) {
 	    pdfh->set_runid(setup->getCount()); // propagate run id so that it can be used in the plugins, for instance for filename generation
-	    string xx = pdfh->get_info_txt();
-	    if(rank==0) {
-	        cout << "info_txt: " << xx << endl;
-	    }
+
+	    string tmp_infotxt = pdfh->get_info_txt();
+	    und->plugin_info_txt.push_back(tmp_infotxt);
+	    stringstream tmp_prefix;
+	    tmp_prefix << "/Field/" << setup->diagpluginfield_.at(kk).obj_prefix;
+	    und->plugin_hdf5_prefix.push_back(tmp_prefix.str());
+
             diag.add_field_diag(pdfh);
             if(rank==0) {
                 cout << "DONE: Registered DiagFieldHook" << endl;
@@ -64,10 +69,13 @@ bool Gencore::run(const char *file, Beam *beam, vector<Field*> *field, Setup *se
 		bool diaghook_ok = pdbh->init(&setup->diagpluginbeam_.at(kk));
 		if(diaghook_ok) {
 			pdbh->set_runid(setup->getCount()); // propagate run id so that it can be used in the plugins, for instance for filename generation
-			string xx = pdbh->get_info_txt();
-			if(rank==0) {
-				cout << "info_txt: " << xx << endl;
-			}
+
+			string tmp_infotxt = pdbh->get_info_txt();
+			und->plugin_info_txt.push_back(tmp_infotxt);
+			stringstream tmp_prefix;
+			tmp_prefix << "/Beam/" << setup->diagpluginbeam_.at(kk).obj_prefix;
+			und->plugin_hdf5_prefix.push_back(tmp_prefix.str());
+
 			diag.add_beam_diag(pdbh);
 			if(rank==0) {
 				cout << "DONE: Registered DiagBeamHook" << endl;

--- a/src/IO/Output.cpp
+++ b/src/IO/Output.cpp
@@ -292,16 +292,17 @@ void Output::writeGroup(std::string group, std::map<std::string,std::vector<doub
     return;
 }
 
-void Output::writeDataset(hid_t gid, string path, std::vector<double> &val, std::string unit, bool single){
-
+void Output::writeDataset(hid_t gid, string path, std::vector<double> &val, std::string unit, bool single)
+{
     std::size_t pos = path.find("/");
     if (pos == std::string::npos) {
         if (single) {
             this->writeSingleNode(gid, path.c_str(),unit.c_str(), &val);
         } else {
-            this->writeBuffer(gid, path.c_str(), unit. c_str(), &val);
+            this->writeBuffer(gid, path.c_str(), unit.c_str(), &val);
         }
     }  else {
+        /* recursive procedure: split path of HDF5 obj to write and (1) open/create first part, then (2) continue (and split again, if needed) */
         string group = path.substr(0,pos);
         hid_t gsub;
         if (this->groupExists(gid,group)){

--- a/src/IO/Output.cpp
+++ b/src/IO/Output.cpp
@@ -45,9 +45,8 @@ void Output::close(){
 }
 
 
-void Output::open(string file, int s0_in, int ds_in)
+bool Output::open(string file, int s0_in, int ds_in)
 {
-
   // s0 = slice number of first slice for a given node
   // ds = number of slices, which are kept by a given node
 
@@ -65,7 +64,7 @@ void Output::open(string file, int s0_in, int ds_in)
   fid=H5Fcreate(file.c_str(),H5F_ACC_TRUNC, H5P_DEFAULT,pid);
   H5Pclose(pid);
 #else
-  create_outfile(&fid, file);
+  return(create_outfile(&fid, file));
 #endif
 }
 

--- a/src/IO/readBeamHDF5.cpp
+++ b/src/IO/readBeamHDF5.cpp
@@ -18,16 +18,19 @@ void ReadBeamHDF5::close(){
 
 bool ReadBeamHDF5::readGlobal(int rank, int size,string file, Setup *setup, Time *time, bool dotime)
 {
-
-
   isOpen=false;
+  double reflen=-1.;
+  int nbins=-1,one4one=-1;
+
+
+  if ((fid=H5Fopen(file.c_str(),H5F_ACC_RDONLY,H5P_DEFAULT)) == H5I_INVALID_HID) {
+    if(0==rank) {
+      cout << "*** Error: unable to open file " << file << endl;
+    }
+    return(false);
+  }
+
   // read global data
-
-  double reflen;
-  int nbins,one4one;
-
-
-  fid=H5Fopen(file.c_str(),H5F_ACC_RDONLY,H5P_DEFAULT);  
   readDataDouble(fid,(char *)"refposition",&s0,1);
   readDataDouble(fid,(char *)"slicelength",&reflen,1);
   readDataDouble(fid,(char *)"slicespacing",&slicelen,1);

--- a/src/Lattice/Lattice.cpp
+++ b/src/Lattice/Lattice.cpp
@@ -28,7 +28,7 @@ bool Lattice::parse(string filename, string beamline, int rank)
   LatticeParser parser;
   matched=false;
 
-  if (rank == 0) { cout << "Parsing lattice file..." << endl; }
+  if (rank == 0) { cout << "Parsing lattice file " << filename << " ..." << endl; }
   bool err=parser.parse(filename,beamline,rank, lat);
   if (err==false) { 
     return err; 

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -69,9 +69,9 @@ bool MPISingle;  // global variable to do mpic or not
 //vector<double> evtime;
 //double evt0;
 
-int genmain (string mainstring, map<string,string> &comarg, bool split) {
-
-    meta_inputfile=mainstring;
+int genmain (string inputfile, map<string,string> &comarg, bool split)
+{
+    meta_inputfile=inputfile;
     int ret=0;
     MPISingle=split;
 	int rank,size;
@@ -140,7 +140,11 @@ int genmain (string mainstring, map<string,string> &comarg, bool split) {
 
     //-----------------------------------------------------------
     // main loop for parsing
-    parser.open(mainstring,rank);
+    parser.open(inputfile,rank);
+    if(0==rank) {
+        cout << "Opened input file " << inputfile << endl;
+    }
+
 
         while(true){
           bool parser_result = parser.parse(&element,&argument);

--- a/src/Main/Setup.cpp
+++ b/src/Main/Setup.cpp
@@ -32,6 +32,7 @@ Setup::Setup()
   exclude_aux_output=false;
   exclude_current_output=true;
   exclude_field_dump=false;
+  do_write_outfile=true;
 
   // filtering of beam slices during dump process (information is forwarded into active instance of Beam class when actually needed there)
   BWF_set_enabled(false);

--- a/src/Main/Setup.cpp
+++ b/src/Main/Setup.cpp
@@ -40,6 +40,7 @@ Setup::Setup()
   // count of runs in conjunction of calls of altersetup
   runcount = 0;
 
+  write_meta_file=false;
   sema_file_enabled_start=false;
   sema_file_enabled_done=false;
 }
@@ -71,6 +72,7 @@ void Setup::usage(){
   cout << " bool exclude_aux_output = false" << endl;
   cout << " bool exclude_current_output = true" << endl;
   cout << " bool exclude_field_dump = false" << endl;
+  cout << " bool write_meta_file = false" << endl;
   cout << " bool write_semaphore_file = false" << endl;
   cout << " bool write_semaphore_file_done = false" << endl;
   cout << " bool write_semaphore_file_started = false" << endl;
@@ -108,6 +110,7 @@ bool Setup::init(int inrank, map<string,string> *arg, Lattice *lat, FilterDiagno
   if (arg->find("exclude_current_output")!=end)   {exclude_current_output  = atob(arg->at("exclude_current_output"));   arg->erase(arg->find("exclude_current_output"));}
   if (arg->find("exclude_field_dump")!=end)   {exclude_field_dump  = atob(arg->at("exclude_field_dump"));   arg->erase(arg->find("exclude_field_dump"));}
 
+  if (arg->find("write_meta_file")!=end)   {write_meta_file = atob(arg->at("write_meta_file"));   arg->erase(arg->find("write_meta_file"));}
   if (arg->find("write_semaphore_file")!=end)   {sema_file_enabled_done  = atob(arg->at("write_semaphore_file"));   arg->erase(arg->find("write_semaphore_file"));}
   /* alias for write_semaphore_file */
   if (arg->find("write_semaphore_file_done")!=end)   {sema_file_enabled_done  = atob(arg->at("write_semaphore_file_done"));   arg->erase(arg->find("write_semaphore_file_done"));}


### PR DESCRIPTION
- More I/O error handling (now also for .out.h5 file)
- Report names of main input file and lattice file while processing them
- Added option to write copy of simulation metadata also to small, independent file. Then the metadata (version information etc.) can be preserved when removing the .out.h5 file. Controlled by new parameter `write_meta_file` in `&setup`.
- Enforce loading of correct plugin type. So far a field plugin .so file could be loaded as plugin for beam  diagnostics, which resulted in a crash. Now an error msg is displayed.
- Store `info_txt` field provided by plugins into metadata in `.out.h5` file. This user defined string can for instance contain the git commit ID of the source that was used to build the module.
- Debug option to skip writing of .out.h5 file (set dbg_suppress_outfile=true in &track)
- Reports now meaningful error message `*** Error: unable to open file x.par.h5` (error message used to be somewhat misleading `*** Error: Mismatch between reference length of run and of input file`)

