### PR TITLE
exit code=1 in case of illegal arguments or missing input filename

### DIFF
--- a/src/Main/mainwrap.cpp
+++ b/src/Main/mainwrap.cpp
@@ -40,7 +40,9 @@ void G4_usage_and_stop(void)
 
     MPI_Barrier(MPI_COMM_WORLD);
     MPI_Finalize(); // node turned off
-    exit(0);
+
+    // non-zero exit code signals error, for instance to SLURM
+    exit(1);
 }
 
 int main (int argc, char *argv[])


### PR DESCRIPTION
Change exit code to 1 in case of illegal arguments or missing input filename.
So far the exit code in these cases was 0, so SLURM was incorrectly reporting "success".