### PR TITLE
Fix memory leak of wakegeo, wakerou and wakeext

### DIFF
--- a/src/Main/Wake.cpp
+++ b/src/Main/Wake.cpp
@@ -117,9 +117,10 @@ bool Wake::init(int rank, int size, map<string,string> *arg,  Time *time, Setup 
   // transfer wakes into beam class
   beam->initWake(ns,nsNode, ds,wakeext,wakeres,wakegeo,wakerou,ztrans,radius,transient);
 
-  delete[] wakeres,wakegeo,wakerou,wakeext;
-
-  
+  delete[] wakeres;
+  delete[] wakegeo;
+  delete[] wakerou;
+  delete[] wakeext;
 
   return true;
 


### PR DESCRIPTION
Building Genesis4 clued me into a bug in the master branch, a memory leak of 3 arrays in `Wake.cpp` post-`init()`:
```
2023-12-04T23:03:48.8335470Z /Users/runner/Miniforge3/conda-bld/genesis4_1701730808588/work/src/Main/Wake.cpp:120:20: warning: left operand of comma operator has no effect [-Wunused-value]
2023-12-04T23:03:48.8434770Z   delete[] wakeres,wakegeo,wakerou,wakeext;
2023-12-04T23:03:48.8535100Z                    ^~~~~~~
2023-12-04T23:03:48.8592490Z /Users/runner/Miniforge3/conda-bld/genesis4_1701730808588/work/src/Main/Wake.cpp:120:28: warning: left operand of comma operator has no effect [-Wunused-value]
2023-12-04T23:03:48.8695580Z   delete[] wakeres,wakegeo,wakerou,wakeext;
2023-12-04T23:03:48.8743960Z                            ^~~~~~~
2023-12-04T23:03:48.8843570Z /Users/runner/Miniforge3/conda-bld/genesis4_1701730808588/work/src/Main/Wake.cpp:120:36: warning: expression result unused [-Wunused-value]
2023-12-04T23:03:48.8919660Z   delete[] wakeres,wakegeo,wakerou,wakeext;
2023-12-04T23:03:48.9011940Z                                    ^~~~~~~
```

The `delete [] a, b, c, d` syntax in actuality only deletes `a`, as the comma is not separating arguments to `delete[]` but rather is functioning as the [comma operator](https://en.wikipedia.org/wiki/Comma_operator).
There are a number of examples of this on the Internet ([example](https://stackoverflow.com/questions/3037655/c-delete-syntax)) so you're not alone in thinking this was valid. Clang is the only one that reported the warning in my testing.

(cc @ChristopherMayes )