### PR TITLE
FIX: calculate npart with stride after clearing it

### DIFF
--- a/src/IO/writeBeamHDF5.cpp
+++ b/src/IO/writeBeamHDF5.cpp
@@ -65,6 +65,7 @@ bool WriteBeamHDF5::write(string fileroot, Beam *beam, int stride)
     s0=-1;
     if ((i>=smin) && (i<smax)){
       s0=0;    // select the slice which is writing
+      npart = 0;
       for (int icount = 0; icount < beam->beam.at(islice).size(); icount += stride){
           npart++;
       }


### PR DESCRIPTION
## Context

Closes #134 

### Details

Based on my observation in https://github.com/svenreiche/Genesis-1.3-Version4/issues/134#issuecomment-1879235500, I think that `npart` with the new stride option was being calculated erroneously. It looks as though iteration 0 passed without issue, but iteration 1 and beyond would increase linearly with `npart` since `npart` was never reset prior to the for loop.

Does this look like the right fix, @svenreiche?