### PR TITLE
syncing/handshaking with external programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ add_library(genesis13 STATIC
         src/Util/Hammerslay.cpp
         src/Util/Inverfc.cpp
         src/Util/RandomU.cpp
+	src/Util/SimpleHandshake.cpp
         src/Util/Sorting.cpp
         src/Util/StringProcessing.cpp
         src/Util/SemaFile.cpp

--- a/include/Setup.h
+++ b/include/Setup.h
@@ -57,6 +57,7 @@ class Setup: public StringProcessing{
    //   bool   getInputFileNameField(string *);
    bool   getRootName(string *);
    void   setRootName(string *);
+   void   getOutputdir(string *);
    bool   RootName_to_FileName(string *, string *);
    int getCount();
    void incrementCount();
@@ -141,4 +142,5 @@ inline void   Setup::BWF_set_inc(int in)
 
 inline bool   Setup::getSemaEnStart() { return sema_file_enabled_start; }
 inline bool   Setup::getSemaEnDone()  { return sema_file_enabled_done; }
+inline void   Setup::getOutputdir(string *q) {*q = outputdir;}
 #endif

--- a/include/SimpleHandshake.h
+++ b/include/SimpleHandshake.h
@@ -1,0 +1,20 @@
+#ifndef G4_SIMPLEHANDSHAKE_H
+#define G4_SIMPLEHANDSHAKE_H
+
+class SimpleHandshake {
+public:
+	SimpleHandshake();
+	~SimpleHandshake() = default;
+	
+	bool doit(const std::string prefix);
+
+private:
+	void drop_file(const std::string fn);
+	void wait_for_file(const std::string fname);
+
+	int my_rank_;
+	std::string fn_wait_;
+	std::string fn_resume_;
+};
+
+#endif // G4_SIMPLEHANDSHAKE_H

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -50,6 +50,7 @@
 #endif
 #include "SeriesManager.h"
 #include "SeriesParser.h"
+#include "SimpleHandshake.h"
 
 #include <sstream>
 
@@ -425,7 +426,14 @@ int genmain (string mainstring, map<string,string> &comarg, bool split) {
             break;
           }
 
-
+	      if (element.compare("&simple_handshake")==0){
+            SimpleHandshake *hs=new SimpleHandshake;
+            string prefix;
+            setup->getOutputdir(&prefix);
+	        if (!hs->doit(prefix)){ break;}
+            delete hs;
+            continue;  
+          } 
 
           //-----------------------------------------------------
           // error because the element typ is not defined

--- a/src/Util/SimpleHandshake.cpp
+++ b/src/Util/SimpleHandshake.cpp
@@ -1,0 +1,98 @@
+/*
+ * Simple handshaking with files.
+ * 
+ * C. Lechner, EuXFEL, 2023-Nov
+ * 
+ * Was implemented to trigger processing of dumped field distribution
+ * before subsequent loading. Of course, the processing program needs
+ * to be already running...
+ * 
+ * FIXME: Currently uses MPI_Barrier, which does busy waiting.
+ */
+
+#include <fstream>
+#include <iostream>
+#include <unistd.h>
+#include <mpi.h>
+
+#include "SimpleHandshake.h"
+
+using namespace std;
+
+SimpleHandshake::SimpleHandshake() {
+	MPI_Comm_rank(MPI_COMM_WORLD, &my_rank_);
+
+	// these are the filenames relative to the simulation output directory
+	// -> not the complete filenames
+	fn_wait_ = "g4_hs.wait";
+	fn_resume_ = "g4_hs.resume";
+}
+
+void SimpleHandshake::drop_file(const string fn)
+{
+	// code from SemaFile class
+	if (0==my_rank_) {
+		ofstream ofs;
+
+		// Note: already existing files are truncated
+		ofs.open(fn, ofstream::out);
+		if(!ofs) {
+			cout << "error generating semaphore file " << fn << endl;
+		}
+		ofs.close();
+	}
+}
+
+void SimpleHandshake::wait_for_file(const string fname)
+{
+	const string msg_indent = "   ";
+
+	if(0==my_rank_) {
+		cout << msg_indent << "Waiting for file \"" << fname << "\" to be created."<< endl;
+		while(1) {
+			sleep(1);
+
+			// try to remove the flag file (if this operation fails with ENOENT the file was there yet)
+			int r = unlink(fname.c_str());
+			if(0==r) {
+				// Success: this means the file was there and could therefore be deleted
+				cout << msg_indent << "Detected (and removed) file \"" << fname << "\"" << endl;
+				break;
+			}
+		}
+	}
+
+	/*
+	 * MPI_Barrier: All processes wait until rank 0 arrives as well.
+	 * FIXME: Busy waiting on all CPUs, replace the MPI_Barrier by something better that puts processes to sleep.
+	 */
+	MPI_Barrier(MPI_COMM_WORLD);
+	if(0==my_rank_) {
+		cout << msg_indent << "Execution of GENESIS continues" << endl;
+	}
+}
+
+bool SimpleHandshake::doit(const string prefix)
+{
+	if(0==my_rank_) {
+		cout << endl << "SimpleHandshake" << endl;
+	}
+
+	// if output directory is defined, prefix has a trailing "/"
+	// if no output dir defined, prefix is empty string
+	const string path_wait   = prefix+fn_wait_;
+	const string path_resume = prefix+fn_resume_;
+
+	// Delete any "resume" file that may still be there from a previous
+	// run before dropping the "wait" file (not handling the error
+	// that we get if there is no such file)
+	unlink(path_resume.c_str());
+	drop_file(path_wait);
+	wait_for_file(path_resume);
+
+	if(0==my_rank_) {
+		cout << endl;
+	}
+
+	return(true);
+}


### PR DESCRIPTION
Arriving at the newly introduced command block `&simple_handshake` (in the moment it has no parameters), the file `g4_hs.wait` is generated and the simulation process waits. Once the file `g4_hs.resume` appears in the working directory of the simulation run, the simulation resumes.

Currently this function is useful mainly for testing and debugging. Provided the capability to replace already existing fields is added to GENESIS (it appears that only a few modifications and checks have to be added to field loading code), this could for instance be used to propagate the dumped light field through a complex optical system with external software and then continue the GENESIS simulation with the result of the propagation process.

While in the moment the wait is done with `MPI_Barrier`, resulting in busy waiting (all cores at 100% CPU utilization when executed with OpenMPI), this behavior could be changed in the future.