### PR TITLE
improve waiting in simple_handshake block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
-### [4.6.6] 
+
+### [4.6.6] - 2024/01/10
 - fixed: exclude_current_output switch in &setup had no effect
 - fixed: a requested bunching factor is now reproduced correctly for large values 
 

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -1,0 +1,4 @@
+# Change Log (unreleased Developer Version)
+back to: [Change Log](CHANGELOG.md)
+
+- 2024/01/11: added `&simple_handshake` for syncing/handshaking with external programs

--- a/include/SimpleHandshake.h
+++ b/include/SimpleHandshake.h
@@ -9,12 +9,15 @@ public:
 	bool doit(const std::string prefix);
 
 private:
+	void join(void);
 	void drop_file(const std::string fn);
 	void wait_for_file(const std::string fname);
 
-	int my_rank_;
 	std::string fn_wait_;
 	std::string fn_resume_;
+
+	int my_rank_;
+	bool busy_wait_ {false};
 };
 
 #endif // G4_SIMPLEHANDSHAKE_H

--- a/include/SimpleHandshake.h
+++ b/include/SimpleHandshake.h
@@ -1,20 +1,24 @@
 #ifndef G4_SIMPLEHANDSHAKE_H
 #define G4_SIMPLEHANDSHAKE_H
 
+#include <map>
+#include <string>
+
 class SimpleHandshake {
 public:
 	SimpleHandshake();
 	~SimpleHandshake() = default;
 	
-	bool doit(const std::string prefix);
+	bool doit(std::map<std::string,std::string> *, const std::string prefix);
 
 private:
+	void usage(void);
 	void join(void);
 	void drop_file(const std::string fn);
 	void wait_for_file(const std::string fname);
 
-	std::string fn_wait_;
-	std::string fn_resume_;
+	std::string ext_wait_;
+	std::string ext_resume_;
 
 	int my_rank_;
 	bool busy_wait_ {false};

--- a/manual/MAIN_INPUT.md
+++ b/manual/MAIN_INPUT.md
@@ -37,6 +37,7 @@ The following describes all supported namelist with their variables, including i
   - [sort](#sort)
   - [write](#write)
   - [track](#track)
+  - [simple_handshake](#simple_handshake)
 
 <div style="page-break-after: always; visibility: hidden"> \pagebreak </div>
 
@@ -416,6 +417,11 @@ This namelist initiate the actually tracking through the undulator and then writ
 - `beam_dump_step` (*int, 0*): Defines the number of integration steps before a particle dump is written. Be careful because for time-dependent simulation it can generate many large output files.
 -  `sort_step` (*int,0*): Defines the number of steps of integration before the particle distribution is sorted. Works only for one-4-one simulations.
 
+[Back](#supported-namelists)
+
+### simple_handshake
+This namelist enables synchronization of the simulation progress with external programs. Arriving at this namelist, an empty file (default name: `g4_hs.wait`) is generated in the working directory of the simulation. The simulation resumes once a second file is detected (default name: `g4_hs.resume`).
+The parameter `file` (*string, default value: `g4_hs`*) allows to change the filenames used for synchronization.
 [Back](#supported-namelists)
 
 <div style="page-break-after: always; visibility: hidden"> \pagebreak </div>

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -452,14 +452,16 @@ int genmain (string inputfile, map<string,string> &comarg, bool split) {
             break;
         }
 
-	      if (element.compare("&simple_handshake")==0){
+        //----------------------------------------------------
+        // handshake/sync. with external programs
+        if (element.compare("&simple_handshake")==0){
             SimpleHandshake *hs=new SimpleHandshake;
             string prefix;
             setup->getOutputdir(&prefix);
-	        if (!hs->doit(prefix)){ break;}
+            if (!hs->doit(&argument, prefix)){ break;}
             delete hs;
             continue;  
-          } 
+        } 
 
         //-----------------------------------------------------
         // error because the element typ is not defined

--- a/src/Util/SimpleHandshake.cpp
+++ b/src/Util/SimpleHandshake.cpp
@@ -1,13 +1,11 @@
 /*
  * Simple handshaking with files.
  * 
- * C. Lechner, EuXFEL, 2023-Nov
+ * C. Lechner, EuXFEL, 2023-Nov/2024-Jan
  * 
  * Was implemented to trigger processing of dumped field distribution
  * before subsequent loading. Of course, the processing program needs
  * to be already running...
- * 
- * FIXME: Currently uses MPI_Barrier, which does busy waiting.
  */
 
 #include <fstream>
@@ -24,6 +22,7 @@ using namespace std;
 SimpleHandshake::SimpleHandshake() {
 	MPI_Comm_rank(MPI_COMM_WORLD, &my_rank_);
 	
+	// controls MPI synchronization method
 	busy_wait_ = false;
 
 	// these are the file extensions
@@ -119,16 +118,15 @@ bool SimpleHandshake::doit(map<string,string> *arg, const string prefix)
 
 	auto end=arg->end();
 	string file = "g4_hs";
-    if (arg->find("file")!=end){file = arg->at("file"); arg->erase(arg->find("file"));}
-    if (!arg->empty()){
-      if (my_rank_==0){ cout << "*** Error: Unknown elements in &simple_handshake" << endl; usage();}
-      return(false);
-    }
+	if (arg->find("file")!=end){file = arg->at("file"); arg->erase(arg->find("file"));}
+	if (!arg->empty()){
+	  if (my_rank_==0){ cout << "*** Error: Unknown elements in &simple_handshake" << endl; usage();}
+	  return(false);
+	}
 
 	// If output directory is defined, prefix has a trailing "/",
 	// if no output dir defined, prefix is empty string.
-	// All names relative to the simulation output directory
-	// -> not the complete filenames
+	// All names relative to the current working directory
 	const string path_wait   = prefix+file+ext_wait_;
 	const string path_resume = prefix+file+ext_resume_;
 


### PR DESCRIPTION
Now the default is that waiting GENESIS processes do not burn CPU time. The processors can be used for other tasks. The names of the files used for the synchronization can now be adjusted using the parameter "file". Documentation was added.

Additionally, created new, separate CHANGELOG_DEV.md to collect changes during the development process. During the release process, these changes would be moved over to the "main" CHANGELOG.md.