### PR TITLE
conversion of data storage in class Collective to std::vector

### DIFF
--- a/include/Collective.h
+++ b/include/Collective.h
@@ -37,11 +37,10 @@ private:
    unsigned int ns;
    int size,rank,ncur;
    double *wakeext, *wakeint, *wakeres, *wakegeo, *wakerou, *wake, *current, *dcurrent;
-   // double *cur;
    std::vector<double> cur;
    int *count;
 
-
+   void resize_and_zero(std::vector<double>&, size_t);
 };
 
 inline bool Collective::hasWakeDefined() const{

--- a/include/Collective.h
+++ b/include/Collective.h
@@ -36,8 +36,7 @@ private:
    double ds,dscur;
    unsigned int ns;
    int size,rank,ncur;
-   double *wakeext, *wakeres, *wakegeo, *wakerou, *wake, *current, *dcurrent;
-   std::vector<double> wakeint;
+   std::vector<double> wakeext, wakeint, wakeres, wakegeo, wakerou, wake, current, dcurrent;
    std::vector<double> cur;
    std::vector<int> count;
 

--- a/include/Collective.h
+++ b/include/Collective.h
@@ -36,11 +36,13 @@ private:
    double ds,dscur;
    unsigned int ns;
    int size,rank,ncur;
-   double *wakeext, *wakeint, *wakeres, *wakegeo, *wakerou, *wake, *current, *dcurrent;
+   double *wakeext, *wakeres, *wakegeo, *wakerou, *wake, *current, *dcurrent;
+   std::vector<double> wakeint;
    std::vector<double> cur;
-   int *count;
+   std::vector<int> count;
 
    void resize_and_zero(std::vector<double>&, size_t);
+   void resize_and_zero_i(vector<int>& v, size_t n);
 };
 
 inline bool Collective::hasWakeDefined() const{

--- a/src/Core/Collective.cpp
+++ b/src/Core/Collective.cpp
@@ -164,10 +164,11 @@ void Collective::update(Beam *beam, double zpos)
   for (int is=0; is <ns ; is++){
     double s=ds*static_cast<double> (is);
     unsigned int idx=static_cast<int> (floor(s/dscur));
+    /* FIXME: range checking needed here (to avoid possible issues with floor operation resulting in idx=-1? */
     double wei=1-(s-idx*dscur)/dscur;  
-    current[is]=wei*cur[idx]+(1-wei)*cur[idx+1];
+    current[is]=wei*cur.at(idx)+(1-wei)*cur.at(idx+1);
     current[is]*=ds/ce;   // convert current to number of electrons
-    dcurrent[is]=-(cur[idx+1]-cur[idx])*ds/ce/dscur;
+    dcurrent[is]=-(cur.at(idx+1)-cur.at(idx))*ds/ce/dscur;
     wake[is]=0;
   }
  

--- a/src/Core/Collective.cpp
+++ b/src/Core/Collective.cpp
@@ -35,13 +35,17 @@ void Collective::clearWake(){
     hasWake = false;
 }
 
+void Collective::resize_and_zero(vector<double>& v, size_t n)
+{
+  v.resize(n);
+  for(size_t j=0; j<n; j++)
+    v.at(j)=0;
+}
+
 void Collective::initWake(unsigned int ns_in, unsigned int nsNode, double ds_in, double *wakeext_in, double *wakeres_in, double *wakegeo_in, double * wakerou_in, double ztrans_in, double radius_in, bool transient_in)
 { 
-
-
   MPI_Comm_rank(MPI_COMM_WORLD, &rank); // assign rank to node
   MPI_Comm_size(MPI_COMM_WORLD, &size); // assign ranksize to node
-
   if (MPISingle){
       rank=0;
       size=1;
@@ -69,11 +73,7 @@ void Collective::initWake(unsigned int ns_in, unsigned int nsNode, double ds_in,
   count   = new int [nsNode];
 
   // array to hold current profile with simulation resolution.
-  // cur     = new double[ncur+1];
-  cur.resize(ncur+1);
-  for(int kk=0; kk<ncur+1; kk++)
-    cur[kk]=0;
-
+  resize_and_zero(cur,ncur+1);
 
   wake    = new double[ns];
   wakegeo = new double[ns];

--- a/src/Core/Collective.cpp
+++ b/src/Core/Collective.cpp
@@ -22,15 +22,15 @@ Collective::~Collective()
 
 void Collective::clearWake(){
     if (hasWake){
-        delete [] wake;
-        delete [] wakegeo;
-        delete [] wakeres;
-        delete [] wakerou;
-        delete [] current;
-        delete [] dcurrent;
-        delete [] wakeext;
-        //delete [] wakeint;
-        //delete [] count;
+        wake.clear();
+        wakegeo.clear();
+        wakeres.clear();
+        wakerou.clear();
+        current.clear();
+        dcurrent.clear();
+        wakeext.clear();
+        wakeint.clear();
+        count.clear();
     }
     hasWake = false;
 }
@@ -73,21 +73,20 @@ void Collective::initWake(unsigned int ns_in, unsigned int nsNode, double ds_in,
   radius=radius_in;
   transient=transient_in;
 
- 
-
-  wakeext = new double[nsNode];  // global wake, explicityle defined in input deck (e.g. constant energy loss)
-  resize_and_zero(wakeint,nsNode);  // wake, internally calculated when updating the wake potential (e.g. sorting)
-  resize_and_zero_i(count,nsNode);
 
   // array to hold current profile with simulation resolution.
   resize_and_zero(cur,ncur+1);
 
-  wake    = new double[ns];
-  wakegeo = new double[ns];
-  wakeres = new double[ns];
-  wakerou = new double[ns];
-  current = new double[ns];
-  dcurrent= new double[ns];
+  resize_and_zero(wakeext, nsNode);  // global wake, explicityle defined in input deck (e.g. constant energy loss)
+  resize_and_zero(wakeint, nsNode);  // wake, internally calculated when updating the wake potential (e.g. sorting)
+  resize_and_zero_i(count, nsNode);
+
+  resize_and_zero(wake,    ns);
+  resize_and_zero(wakegeo, ns);
+  resize_and_zero(wakeres, ns);
+  resize_and_zero(wakerou, ns);
+  resize_and_zero(current, ns);
+  resize_and_zero(dcurrent,ns);
 
   // fill the wakes or single particle wakes
   for (int i=0; i <nsNode; i++){

--- a/src/Core/Collective.cpp
+++ b/src/Core/Collective.cpp
@@ -210,7 +210,20 @@ void Collective::update(Beam *beam, double zpos)
       wakeloc+=current[is+i]*(wakeres[i]+wakerou[i]);
       wakeloc+=dcurrent[is+i]*wakegeo[i];
     }
-    int idx = floor((s-sc0)/dscur);
+    
+    double floorarg = (s-sc0)/dscur;
+    int idx = floor(floorarg);
+    /* Lechner, 2024-Jan: workaround (range checking) from commit id 28dd1fb, use only until issue is fixed */
+    if(idx<0) {
+        const double eps=1.0e-10;
+        if(floorarg >= -eps) {
+			idx=0;
+            cout << "workaround/hack in Collective.cpp: set idx=" << idx << ", floorarg=" << floorarg << endl;
+        } else {
+            cout << "!!! BADSTUFF in Collective.cpp: idx=" << idx << ", floorarg=" << floorarg << endl;
+            abort();
+        }
+    }
     count.at(idx)++;
     wakeint.at(idx)+=wakeloc;
   }


### PR DESCRIPTION
As a first step to fix the memory corruption issues reported in bug report https://github.com/svenreiche/Genesis-1.3-Version4/issues/144 , the data arrays were replaced by std::vector. Many (but not all) data accesses are done via `at()`, avoiding that indexing issues go undetected in the future.

As a second step, if possible, the code block should be reworked to use integer arithmetic (and avoid floating point arithmetic) as much as possible to avoid the rounding issues reported in https://github.com/svenreiche/Genesis-1.3-Version4/issues/144 . 
Moreover, since the computation of the parameters done in function `Wake::init` uses several parameters from an instance of class `Time`, it might be useful to pass a const pointer to that instance to `Collective::initWake` instead of these parameters...