### PR TITLE
make workaround in Collective.cpp less verbose

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -2,3 +2,4 @@
 back to: [Change Log](CHANGELOG.md)
 
 - 2024/01/11: added `&simple_handshake` for syncing/handshaking with external programs
+- 2024/01/20: fix of stability issue in `Collective::update` (issue affected simulations with `&wake` block)

--- a/include/Collective.h
+++ b/include/Collective.h
@@ -40,6 +40,8 @@ private:
    std::vector<double> cur;
    std::vector<int> count;
 
+   unsigned long long loc_count_workaround;
+
    void resize_and_zero(std::vector<double>&, size_t);
    void resize_and_zero_i(vector<int>& v, size_t n);
 };

--- a/src/Core/Collective.cpp
+++ b/src/Core/Collective.cpp
@@ -13,6 +13,8 @@ Collective::Collective()
   transient=false;
   ztrans=0;
   radius=1.0;
+
+  loc_count_workaround=0;
 }
 
 Collective::~Collective()
@@ -216,9 +218,16 @@ void Collective::update(Beam *beam, double zpos)
     /* Lechner, 2024-Jan: workaround (range checking) from commit id 28dd1fb, use only until issue is fixed */
     if(idx<0) {
         const double eps=1.0e-10;
+        loc_count_workaround++;
         if(floorarg >= -eps) {
-			idx=0;
-            cout << "workaround/hack in Collective.cpp: set idx=" << idx << ", floorarg=" << floorarg << endl;
+            idx=0;
+            if(1==loc_count_workaround) {
+                cout << "workaround/hack in Collective.cpp: set idx=" << idx << ", floorarg=" << floorarg << endl;
+            } else if (2==loc_count_workaround) {
+                cout << "workaround/hack in Collective.cpp: set idx=" << idx << ", floorarg=" << floorarg << " (not reporting further interventions)" << endl;
+            } else {
+                /* only reporting the first two interventions */
+            }
         } else {
             cout << "!!! BADSTUFF in Collective.cpp: idx=" << idx << ", floorarg=" << floorarg << endl;
             abort();


### PR DESCRIPTION
In every MPI process, only report first two interventions. The user is informed about the activity of the workaround, but stdout logfiles are no longer filled with lots of repeating messages.