### PR TITLE
reorganize #include "version.h"

### DIFF
--- a/include/HDF5base.h
+++ b/include/HDF5base.h
@@ -13,8 +13,6 @@
 
 #include <hdf5.h>
 
-#include "version.h"
-
 using namespace std;
 
 class HDF5Base{

--- a/include/Output.h
+++ b/include/Output.h
@@ -12,7 +12,6 @@
 #include "Beam.h"
 #include "Field.h"
 #include "Undulator.h"
-#include "version.h"
 
 using namespace std;
 

--- a/src/IO/HDF5base.cpp
+++ b/src/IO/HDF5base.cpp
@@ -1,4 +1,5 @@
 #include "HDF5base.h"
+#include "version.h"
 
 #include <mpi.h>
 

--- a/src/IO/Output.cpp
+++ b/src/IO/Output.cpp
@@ -1,4 +1,6 @@
 #include "Output.h"
+#include "version.h"
+
 #include <stdlib.h>
 
 // Meta info

--- a/src/Main/mainwrap.cpp
+++ b/src/Main/mainwrap.cpp
@@ -7,8 +7,9 @@
 
 #include <getopt.h>
 
-//#include "VersionInfo.h"
 #include "version.h"
+
+
 using namespace std;
 
 // very basic wrapper for genesis. Most of the genesis stuff is moved into genmain.


### PR DESCRIPTION
To include the git commit id of the source code into the compiled binary, the build process uses the header file "version.h", that is generated every time `make` is ran. So far this header file was in turn included by other header files, resulting in many dependencies from a file changing during every time a build is done.

This patch removes the includes from other header files and "version.h" is instead included directly where it is needed.

Test case (run it in your build directory):
```
cmake -DCMAKE_BUILD_TYPE=Debug ..
make
make
```

With the source files in commit id 4681421b (date: 2024-03-20), invoking `make` a second time (without changing any source file) results in the compilation of 41 cpp source files (takes a bit above a minute in my development environment).
With the changes in this patch, invoking `make` the second time compiles only 4 cpp source files.
