### PR TITLE
test environment for diagnostic plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,3 +197,6 @@ add_dependencies(genesis13 get_git_hash)
 add_executable(genesis4 src/Main/mainwrap.cpp)
 
 target_link_libraries(genesis4 genesis13 ${_libraries})
+
+
+add_subdirectory(misc/plugin_testbench)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,5 +198,7 @@ add_executable(genesis4 src/Main/mainwrap.cpp)
 
 target_link_libraries(genesis4 genesis13 ${_libraries})
 
-
-add_subdirectory(misc/plugin_testbench)
+# Compilation of plugin testbench only when plugin system is requested
+if(USE_DPI)
+   add_subdirectory(misc/plugin_testbench)
+endif()

--- a/misc/plugin_testbench/CMakeLists.txt
+++ b/misc/plugin_testbench/CMakeLists.txt
@@ -1,6 +1,9 @@
 project(g4_tb)
 
-add_executable(g4_tb g4_tb.cpp)
+add_executable(g4_tb
+	g4_tb.cpp
+	g4_tb_util.cpp
+)
 
 ### copied from top-level CMakeLists.txt file ###
 # The -DFFTW=1 is cruical: otherwise the storage layout of class

--- a/misc/plugin_testbench/CMakeLists.txt
+++ b/misc/plugin_testbench/CMakeLists.txt
@@ -1,4 +1,20 @@
 project(g4_tb)
 
 add_executable(g4_tb g4_tb.cpp)
+
+### copied from top-level CMakeLists.txt file ###
+# The -DFFTW=1 is cruical: otherwise the storage layout of class
+# DiagnosticFieldBase is different in g4_tb and the code blocks
+# compiled for the "GENESIS 1.3" binary (such as
+# src/Core/DiagnosticHook.cpp and src/Core/DiagnosticHookLI.cpp)
+if (TARGET PkgConfig::FFTW)
+    message(STATUS "Defining the macro FFTW in the source code")
+    target_compile_definitions(g4_tb PRIVATE FFTW=1)
+endif()
+if(USE_DPI)
+   target_compile_definitions(g4_tb PRIVATE USE_DPI)
+endif()
+### end of copied definitions ###
+
+
 target_link_libraries(g4_tb genesis13 ${_libraries})

--- a/misc/plugin_testbench/CMakeLists.txt
+++ b/misc/plugin_testbench/CMakeLists.txt
@@ -1,0 +1,4 @@
+project(g4_tb)
+
+add_executable(g4_tb g4_tb.cpp)
+target_link_libraries(g4_tb genesis13 ${_libraries})

--- a/misc/plugin_testbench/README.md
+++ b/misc/plugin_testbench/README.md
@@ -1,0 +1,76 @@
+# README
+Christoph Lechner, European XFEL
+Version: April 2024
+
+## Overview
+In this directory you find the source code of a test environment for field analysis plugins (currently, plugins for analysis of the electron beam are not supported). This test environment allows to perform tests without having to run a complete "GENESIS 1.3" simulation run.
+
+## Building it
+To build follow the usual procedure to compile "GENESIS 1.3", but with the additional parameter `-DUSE_DPI=ON`:
+```
+% cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_DPI=ON ..
+% make
+```
+This compiles "GENESIS 1.3", v4 and the plugin testbench which re-uses some of the code of "GENESIS 1.3", v4 to perform the tests.
+
+## Using it
+This example was done with git commit ID 3295805.
+
+While this testbench supports MPI, we don't use it here for sake of simplicity. The parameters are specified in a configuration file. This directory contains one example configuration file, `demo_params.txt`. The testbench expects a single argument, the name of the configuration file to use.
+
+Now, we use the testbench to debug a plugin with `gdb`.
+One standard approach to debug the field analysis code is to place a breakpoint at the beginning of the field processing code in the plugin:
+```
+% gdb ./g4_tb
+GNU gdb (GDB) 9.2
+Copyright (C) 2020 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+Type "show copying" and "show warranty" for details.
+This GDB was configured as "x86_64-pc-linux-gnu".
+Type "show configuration" for configuration details.
+For bug reporting instructions, please see:
+<http://www.gnu.org/software/gdb/bugs/>.
+Find the GDB manual and other documentation resources online at:
+    <http://www.gnu.org/software/gdb/documentation/>.
+
+For help, type "help".
+Type "apropos word" to search for commands related to "word"...
+Reading symbols from ./g4_tb...
+(gdb) b DiagFieldHookedDemo::doit
+Function "DiagFieldHookedDemo::doit" not defined.
+Make breakpoint pending on future shared library load? (y or [n]) y
+Breakpoint 1 (DiagFieldHookedDemo::doit) pending.
+(gdb) r demo_params.txt
+Starting program: .../build_20240328/misc/plugin_testbench/g4_tb demo_params.txt
+[Thread debugging using libthread_db enabled]
+Using host libthread_db library "/lib64/libthread_db.so.1".
+[Detaching after fork from child process 75512]
+[New Thread 0x2aaab0691700 (LWP 75525)]
+[New Thread 0x2aaab0a55700 (LWP 75533)]
+opened config file 'demo_params.txt.
+processed config file.
+
+Setting up DiagFieldHook for libfile="./libdemo.so", obj_prefix="plugin"
+DiagFieldHook::init
+Rank 0: Loaded the library, handle is 0x6abf50
+Got the library
+Rank 0: FieldDiag Factory location is 0x2aaab31af686
+Rank 0: FieldDiag Destroyer location is 0x2aaab31af6d4
+Rank 0: BeamDiag Factory location is 0
+Rank 0: BeamDiag Destroyer location is 0
+Rank 0: Calling factory
+Rank 0: Calling get_infos
+Rank 0: Got class instance
+   info_txt="Demo for plugin diagnostics"
+   do_multi=0
+   provides object named my_power
+   provides object named abc
+DONE: Registered DiagFieldHook
+
+Thread 1 "g4_tb" hit Breakpoint 1, DiagFieldHookedDemo::doit (this=0x6ac620, pd=0x7fffffffccf0) at .../misc/plugin_demo/DiagFieldPowerDemo.cc:46
+46              verify_datastructure(pd);
+(gdb)
+```
+The execution stops inside of the plugin being studied. From here on you can use standard debugging techniques.

--- a/misc/plugin_testbench/README.md
+++ b/misc/plugin_testbench/README.md
@@ -13,13 +13,28 @@ To build follow the usual procedure to compile "GENESIS 1.3", but with the addit
 ```
 This compiles "GENESIS 1.3", v4 and the plugin testbench which re-uses some of the code of "GENESIS 1.3", v4 to perform the tests.
 
-## Using it
-This example was done with git commit ID 3295805.
+## Basic usage
+### Single process
+The parameters are specified in a configuration file. This directory contains one example configuration file, `demo_params.txt`. The testbench expects a single argument, the name of the configuration file to use.
+```
+./g4_tb demo_params.txt
+```
+At the end of the execution, a file named `plugin_data.txt` is generated (at the moment the name of this file is hardcoded). The formatting of the file is optimized for import into Python/numpy.
 
-While this testbench supports MPI, we don't use it here for sake of simplicity. The parameters are specified in a configuration file. This directory contains one example configuration file, `demo_params.txt`. The testbench expects a single argument, the name of the configuration file to use.
+### In MPI environment
+FEL simulations with "GENESIS 1.3", v4 typically run in an MPI environment. The testbench also supports operation in MPI enviroments.
 
-Now, we use the testbench to debug a plugin with `gdb`.
-One standard approach to debug the field analysis code is to place a breakpoint at the beginning of the field processing code in the plugin:
+Depending on the configuration of your MPI environment this can as simple as 
+```
+mpirun ./g4_tb demo_params.txt
+```
+
+Note that in this case the parameter `nslice` in the configuration file specifies the number of slices per process on the MPI communicator. The diagnostics data written to the generated output file contains the data generated in all processes, but only the data generated on MPI rank 0 is written to stdout.
+
+## Usage with gdb
+Now, we illustrate how to use the testbench to debug a plugin with `gdb`. This example was done with git commit ID 3295805.
+
+While the testbench supports MPI, we don't use it here for sake of simplicity. One standard approach to debug the field analysis code is to place a breakpoint at the beginning of the field processing code in the plugin:
 ```
 % gdb ./g4_tb
 GNU gdb (GDB) 9.2

--- a/misc/plugin_testbench/demo_params.txt
+++ b/misc/plugin_testbench/demo_params.txt
@@ -1,4 +1,5 @@
 power = 1
+# in MPI environment this specifies the number of slices per process
 nslice=7
 nz = 5
 lambda = 2e-8

--- a/misc/plugin_testbench/demo_params.txt
+++ b/misc/plugin_testbench/demo_params.txt
@@ -1,8 +1,6 @@
 power = 1
 nslice=7
 nz = 5
-# this is a not-existing parameter
-bad_parameter = 4
 lambda = 2e-8
 dgrid = 1e-4
 ngrid = 251

--- a/misc/plugin_testbench/demo_params.txt
+++ b/misc/plugin_testbench/demo_params.txt
@@ -1,6 +1,13 @@
-power = 1234
+power = 1
+nslice=7
+nz = 5
+# this is a not-existing parameter
 bad_parameter = 4
 lambda = 2e-8
 dgrid = 1e-4
 ngrid = 251
-libfile = ./libplugin.so
+libfile = ./libdemo.so
+
+# empty lines should not be an issue
+
+ 	# more comments here, with whitespace before the pound sign

--- a/misc/plugin_testbench/demo_params.txt
+++ b/misc/plugin_testbench/demo_params.txt
@@ -1,0 +1,6 @@
+power = 1234
+bad_parameter = 4
+lambda = 2e-8
+dgrid = 1e-4
+ngrid = 251
+libfile = ./libplugin.so

--- a/misc/plugin_testbench/g4_tb.cpp
+++ b/misc/plugin_testbench/g4_tb.cpp
@@ -79,9 +79,15 @@ void dump_result_mtx(ostream& os, const vector<double>& d, const int nz, const i
 }
 void dump_results_core(ostream &os, const map< string,vector<double> >& r, const int nz, const int nslice)
 {
+	int counter = 1; // counter to have unique object names
 	for(auto const &obj: r) {
-		os << "   data in \"" << obj.first << "\"" << endl;
+		// formatting of data matrix optimized for numpy.array
+		os << "# data in \"" << obj.first << "\"" << endl;
+		os << "data" << counter << " = np.array([" << endl;
 		dump_result_mtx(os, obj.second, nz, nslice);
+		os << "])" << endl << endl;
+
+		counter++;
 	}
 }
 void dump_results(ostream &os, TB_Cfg *ptbcfg, const map< string,vector<double> >& r)
@@ -198,15 +204,15 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 	if(rank==0) {
-		cout << "opened config file '" << fncfg << "." << endl;
+		cout << "opened config file '" << fncfg << "'." << endl;
 	}
 	bool parse_ok=ptbcfg->update_from_stream(ifs);
 	ifs.close();
 	if(rank==0) {
 		if(!parse_ok)
-			cout << "processed config file (there were errors)." << endl << endl;
+			cout << "   processed config file (there were errors)." << endl << endl;
 		else
-			cout << "processed config file." << endl << endl;
+			cout << "   processed config file." << endl << endl;
 	}
 
 
@@ -309,7 +315,7 @@ int main(int argc, char **argv)
 	res_collect(ptbcfg, glbl_results, results);
 	if(0==rank) {
 		ofstream ofs;
-		ofs.open("stuff.txt", ofstream::out);
+		ofs.open("plugin_data.txt", ofstream::out);
 		dump_results_core(ofs, glbl_results, ptbcfg->nz, mpisize*ptbcfg->nslice);
 		ofs.close();
 	}

--- a/misc/plugin_testbench/g4_tb.cpp
+++ b/misc/plugin_testbench/g4_tb.cpp
@@ -16,6 +16,7 @@
 #include "DiagnosticHookS.h"
 #include "GaussHermite.h"
 #include "g4_tb_util.h"
+#include "version.h"
 
 using namespace std;
 
@@ -191,7 +192,9 @@ int main(int argc, char **argv)
 	string fncfg(argv[1]);
 
 	if(0==rank) {
-		cout << "name of configuration file: " << fncfg << endl
+		VersionInfo vi;
+		cout << "g4_tb, build info: " << vi.Build() << endl
+		     << "name of configuration file: " << fncfg << endl
 		     << "mpisize = " << mpisize << endl << endl;
 	}
 

--- a/misc/plugin_testbench/g4_tb.cpp
+++ b/misc/plugin_testbench/g4_tb.cpp
@@ -1,0 +1,171 @@
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+#include <mpi.h>
+
+#include "DiagnosticHook.h"
+#include "DiagnosticHookS.h"
+#include "GaussHermite.h"
+
+using namespace std;
+
+const int nslice=2;
+
+
+void prepare_field(vector<Field *> *fieldin)
+{
+    /*** based on LoadField::init in LoadField.cpp ***/
+    Field *field = new Field;
+    // field->init(time->getNodeNSlice(),ngrid,dgrid,lambda,sample*lambda,s[0],harm);
+    const double dgrid = 100e-6;
+    const int ngrid = 151;
+    const double lambda = 1e-10;
+    const int sample = 1;
+    const double s0 = 0;
+    const int harm = 1;
+    field->init(nslice,ngrid,dgrid,lambda,sample*lambda,s0,harm);
+    fieldin->push_back(field);
+    int idx=fieldin->size()-1;
+    
+    complex< double >  *fieldslice = new complex<double> [ngrid*ngrid];
+    FieldSlice slice;
+    GaussHermite gh;
+
+    for (int j=0; j<nslice; j++)
+    {
+        // int i=j+time->getNodeOffset(); // FIXME
+        int i=j; // +time->getNodeOffset(); // FIXME
+        slice.lambda=lambda;
+        slice.power=1e6;
+        slice.phase=0;
+        slice.z0=0;
+        slice.w0=20e-6;
+        slice.xcen=0;
+        slice.ycen=0;
+        slice.xangle=0;
+        slice.yangle=0;
+        slice.nx=0;
+        slice.ny=0;
+        slice.harm=harm;
+        gh.loadGauss(fieldslice,&slice,dgrid,ngrid);
+        for (int k=0; k<ngrid*ngrid;k++){
+            fieldin->at(idx)->field[j].at(k)=fieldslice[k]; 
+        }      
+    }
+    delete[] fieldslice;
+}
+
+void dump_result_mtx(const vector<double> d)
+{
+    cout << "      [";
+
+    // TODO: Organize output as matrix, dimensions being 'nslice' and 'nz'
+    for(int kk=0; ; ) {
+        cout << d.at(kk);
+        kk++;
+        if(kk>=d.size()) {
+            break;
+        }
+        cout << ",";
+    }
+
+    cout << "]";
+    cout << endl;
+}
+void dump_results(const map< string,vector<double> > r)
+{
+    for(auto const &obj: r) {
+        cout << "   data in \"" << obj.first << "\"" << endl;
+        dump_result_mtx(obj.second);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    int rank, size;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    /*** copied from RegPlugin.cpp (commit id 4681421, date: 2024-03-20) ***/
+    string libfile = "./libdemo.so";
+	string obj_prefix = "plugin";
+	string parameter = "";
+	bool verbose = false;
+	bool interface_verbose = false;
+
+    DiagFieldPluginCfg cfg;
+    cfg.obj_prefix = obj_prefix;
+    cfg.libfile = libfile;
+    cfg.parameter = parameter;
+    cfg.lib_verbose = verbose; // controls verbosity in the loaded .so lib
+    cfg.interface_verbose = interface_verbose;
+
+   
+    /*** copied from Gencore.cpp (commit id 4681421, date: 2024-03-20) ***/
+	if(rank==0) {
+        cout << "Setting up DiagFieldHook for libfile=\"" << cfg.libfile << "\", obj_prefix=\"" << cfg.obj_prefix << "\"" << endl;
+    }
+    DiagFieldHook *pdfh = new DiagFieldHook(); /* !do not delete this instance, it will be destroyed when DiagFieldHook instance is deleted! */
+    bool diaghook_ok = pdfh->init(&cfg);
+    if(diaghook_ok) {
+        // pdfh->set_runid(setup->getCount()); // propagate run id so that it can be used in the plugins, for instance for filename generation
+        pdfh->set_runid(1); // propagate run id so that it can be used in the plugins, for instance for filename generation
+
+        string tmp_infotxt = pdfh->get_info_txt();
+        // und->plugin_info_txt.push_back(tmp_infotxt);
+        stringstream tmp_prefix;
+        tmp_prefix << "/Field/" << cfg.obj_prefix;
+        // und->plugin_hdf5_prefix.push_back(tmp_prefix.str());
+
+        // diag.add_field_diag(pdfh);
+        if(rank==0) {
+            cout << "DONE: Registered DiagFieldHook" << endl;
+        }
+    } else {
+        delete pdfh;
+        if(rank==0) {
+            cout << "failed to set up DiagFieldHook, not registering" << endl;
+        }
+    }
+
+    vector<Field *> *fields = new vector<Field *>;
+    prepare_field(fields);
+    
+    /*** Remark, CL, 2024-03-28: Not using field import code from src/Loading/ImportField.cpp yet, because one would have to prepare an instance of class 'Setup'. ***/
+
+    /*** setup data structures for diagnostics data, code from Diagnostic::init in Diagnostic.cpp ***/
+    
+    // Remark on data organization:
+    // in Diagnostic.h:
+    // vector< map< string,vector<double> > > val;
+    // here we use:
+    map< string,vector<double> > results;
+
+    FilterDiagnostics filter;
+    const int nz=2;
+    for(auto const &tag: pdfh->getTags(filter)) {
+        int size = nslice*nz;
+        results[tag.first].resize(size);
+    }
+
+    /*** NOW, run the diagnostics code ***/
+    for(int iz=0; iz<nz; iz++)
+    {
+        for(int ifld=0; ifld<fields->size(); ifld++) {
+            /* this calls the code provided by the plugin, so put breakpoints there if needed */
+            pdfh->getValues(fields->at(ifld), results, iz);
+        }
+    }
+
+    cout << "**********************************" << endl;
+    cout << "Dumping generated diagnostics data" << endl;
+    dump_results(results);
+    
+    /*** TODO: clean up all resources, unload the plugin module etc. ***/
+
+    MPI_Finalize();
+	return(0);
+}

--- a/misc/plugin_testbench/g4_tb.cpp
+++ b/misc/plugin_testbench/g4_tb.cpp
@@ -314,18 +314,22 @@ int main(int argc, char **argv)
 	map< string,vector<double> > glbl_results; // !only populated with collected data on rank 0!
 	res_collect(ptbcfg, glbl_results, results);
 	if(0==rank) {
+		const char *fnout = "plugin_data.txt";
 		ofstream ofs;
-		ofs.open("plugin_data.txt", ofstream::out);
+		ofs.open(fnout, ofstream::out);
 		dump_results_core(ofs, glbl_results, ptbcfg->nz, mpisize*ptbcfg->nslice);
 		ofs.close();
+
+		cout << "Data collected from all processes written to file '" << fnout << "'" << endl;
 	}
     
-	/*** TODO: clean up all resources, unload the plugin module etc. ***/
+	/*** TODO: clean up all resources ***/
 
 	for(int kk=0; kk<fields->size(); kk++) {
 		delete fields->at(kk);
 	}
 	delete fields;
+	delete pdfh; // unloads library
 	delete ptbcfg;
 
 	MPI_Finalize();

--- a/misc/plugin_testbench/g4_tb.cpp
+++ b/misc/plugin_testbench/g4_tb.cpp
@@ -15,157 +15,157 @@ const int nslice=2;
 
 void prepare_field(vector<Field *> *fieldin)
 {
-    /*** based on LoadField::init in LoadField.cpp ***/
-    Field *field = new Field;
-    // field->init(time->getNodeNSlice(),ngrid,dgrid,lambda,sample*lambda,s[0],harm);
-    const double dgrid = 100e-6;
-    const int ngrid = 151;
-    const double lambda = 1e-10;
-    const int sample = 1;
-    const double s0 = 0;
-    const int harm = 1;
-    field->init(nslice,ngrid,dgrid,lambda,sample*lambda,s0,harm);
-    fieldin->push_back(field);
-    int idx=fieldin->size()-1;
-    
-    complex< double >  *fieldslice = new complex<double> [ngrid*ngrid];
-    FieldSlice slice;
-    GaussHermite gh;
+	/*** based on LoadField::init in LoadField.cpp ***/
+	Field *field = new Field;
+	// field->init(time->getNodeNSlice(),ngrid,dgrid,lambda,sample*lambda,s[0],harm);
+	const double dgrid = 100e-6;
+	const int ngrid = 151;
+	const double lambda = 1e-10;
+	const int sample = 1;
+	const double s0 = 0;
+	const int harm = 1;
+	field->init(nslice,ngrid,dgrid,lambda,sample*lambda,s0,harm);
+	fieldin->push_back(field);
+	int idx=fieldin->size()-1;
 
-    for (int j=0; j<nslice; j++)
-    {
-        // int i=j+time->getNodeOffset(); // FIXME
-        int i=j; // +time->getNodeOffset(); // FIXME
-        slice.lambda=lambda;
-        slice.power=1e6;
-        slice.phase=0;
-        slice.z0=0;
-        slice.w0=20e-6;
-        slice.xcen=0;
-        slice.ycen=0;
-        slice.xangle=0;
-        slice.yangle=0;
-        slice.nx=0;
-        slice.ny=0;
-        slice.harm=harm;
-        gh.loadGauss(fieldslice,&slice,dgrid,ngrid);
-        for (int k=0; k<ngrid*ngrid;k++){
-            fieldin->at(idx)->field[j].at(k)=fieldslice[k]; 
-        }      
-    }
-    delete[] fieldslice;
+	complex< double >  *fieldslice = new complex<double> [ngrid*ngrid];
+	FieldSlice slice;
+	GaussHermite gh;
+
+	for (int j=0; j<nslice; j++)
+	{
+		// int i=j+time->getNodeOffset(); // FIXME
+		int i=j; // +time->getNodeOffset(); // FIXME
+		slice.lambda=lambda;
+		slice.power=1e6;
+		slice.phase=0;
+		slice.z0=0;
+		slice.w0=20e-6;
+		slice.xcen=0;
+		slice.ycen=0;
+		slice.xangle=0;
+		slice.yangle=0;
+		slice.nx=0;
+		slice.ny=0;
+		slice.harm=harm;
+		gh.loadGauss(fieldslice,&slice,dgrid,ngrid);
+		for (int k=0; k<ngrid*ngrid;k++){
+			fieldin->at(idx)->field[j].at(k)=fieldslice[k]; 
+		}      
+	}
+	delete[] fieldslice;
 }
 
 void dump_result_mtx(const vector<double> d)
 {
-    cout << "      [";
+	cout << "      [";
 
-    // TODO: Organize output as matrix, dimensions being 'nslice' and 'nz'
-    for(int kk=0; ; ) {
-        cout << d.at(kk);
-        kk++;
-        if(kk>=d.size()) {
-            break;
-        }
-        cout << ",";
-    }
+	// TODO: Organize output as matrix, dimensions being 'nslice' and 'nz'
+	for(int kk=0; ; ) {
+		cout << d.at(kk);
+		kk++;
+		if(kk>=d.size()) {
+			break;
+		}
+		cout << ",";
+	}
 
-    cout << "]";
-    cout << endl;
+	cout << "]";
+	cout << endl;
 }
 void dump_results(const map< string,vector<double> > r)
 {
-    for(auto const &obj: r) {
-        cout << "   data in \"" << obj.first << "\"" << endl;
-        dump_result_mtx(obj.second);
-    }
+	for(auto const &obj: r) {
+		cout << "   data in \"" << obj.first << "\"" << endl;
+		dump_result_mtx(obj.second);
+	}
 }
 
 int main(int argc, char **argv)
 {
-    int rank, size;
+	int rank, size;
 
-    MPI_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
+	MPI_Init(&argc, &argv);
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+	MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-    /*** copied from RegPlugin.cpp (commit id 4681421, date: 2024-03-20) ***/
-    string libfile = "./libdemo.so";
+	/*** copied from RegPlugin.cpp (commit id 4681421, date: 2024-03-20) ***/
+	string libfile = "./libdemo.so";
 	string obj_prefix = "plugin";
 	string parameter = "";
 	bool verbose = false;
 	bool interface_verbose = false;
 
-    DiagFieldPluginCfg cfg;
-    cfg.obj_prefix = obj_prefix;
-    cfg.libfile = libfile;
-    cfg.parameter = parameter;
-    cfg.lib_verbose = verbose; // controls verbosity in the loaded .so lib
-    cfg.interface_verbose = interface_verbose;
+	DiagFieldPluginCfg cfg;
+	cfg.obj_prefix = obj_prefix;
+	cfg.libfile = libfile;
+	cfg.parameter = parameter;
+	cfg.lib_verbose = verbose; // controls verbosity in the loaded .so lib
+	cfg.interface_verbose = interface_verbose;
 
    
-    /*** copied from Gencore.cpp (commit id 4681421, date: 2024-03-20) ***/
+	/*** copied from Gencore.cpp (commit id 4681421, date: 2024-03-20) ***/
 	if(rank==0) {
-        cout << "Setting up DiagFieldHook for libfile=\"" << cfg.libfile << "\", obj_prefix=\"" << cfg.obj_prefix << "\"" << endl;
-    }
-    DiagFieldHook *pdfh = new DiagFieldHook(); /* !do not delete this instance, it will be destroyed when DiagFieldHook instance is deleted! */
-    bool diaghook_ok = pdfh->init(&cfg);
-    if(diaghook_ok) {
-        // pdfh->set_runid(setup->getCount()); // propagate run id so that it can be used in the plugins, for instance for filename generation
-        pdfh->set_runid(1); // propagate run id so that it can be used in the plugins, for instance for filename generation
+		cout << "Setting up DiagFieldHook for libfile=\"" << cfg.libfile << "\", obj_prefix=\"" << cfg.obj_prefix << "\"" << endl;
+	}
+	DiagFieldHook *pdfh = new DiagFieldHook(); /* !do not delete this instance, it will be destroyed when DiagFieldHook instance is deleted! */
+	bool diaghook_ok = pdfh->init(&cfg);
+	if(diaghook_ok)
+	{
+		// pdfh->set_runid(setup->getCount()); // propagate run id so that it can be used in the plugins, for instance for filename generation
+		pdfh->set_runid(1); // propagate run id so that it can be used in the plugins, for instance for filename generation
 
-        string tmp_infotxt = pdfh->get_info_txt();
-        // und->plugin_info_txt.push_back(tmp_infotxt);
-        stringstream tmp_prefix;
-        tmp_prefix << "/Field/" << cfg.obj_prefix;
-        // und->plugin_hdf5_prefix.push_back(tmp_prefix.str());
+		string tmp_infotxt = pdfh->get_info_txt();
+		// und->plugin_info_txt.push_back(tmp_infotxt);
+		stringstream tmp_prefix;
+		tmp_prefix << "/Field/" << cfg.obj_prefix;
+		// und->plugin_hdf5_prefix.push_back(tmp_prefix.str());
 
-        // diag.add_field_diag(pdfh);
-        if(rank==0) {
-            cout << "DONE: Registered DiagFieldHook" << endl;
-        }
-    } else {
-        delete pdfh;
-        if(rank==0) {
-            cout << "failed to set up DiagFieldHook, not registering" << endl;
-        }
-    }
+		// diag.add_field_diag(pdfh);
+		if(rank==0) {
+			cout << "DONE: Registered DiagFieldHook" << endl;
+		}
+	} else {
+		delete pdfh;
+		if(rank==0) {
+			cout << "failed to set up DiagFieldHook, not registering" << endl;
+		}
+	}
 
-    vector<Field *> *fields = new vector<Field *>;
-    prepare_field(fields);
+	vector<Field *> *fields = new vector<Field *>;
+	prepare_field(fields);
+	/*** Remark, CL, 2024-03-28: Not using field import code from src/Loading/ImportField.cpp yet, because one would have to prepare an instance of class 'Setup'. ***/
+
+	/*** setup data structures for diagnostics data, code from Diagnostic::init in Diagnostic.cpp ***/
     
-    /*** Remark, CL, 2024-03-28: Not using field import code from src/Loading/ImportField.cpp yet, because one would have to prepare an instance of class 'Setup'. ***/
+	// Remark on data organization:
+	// in Diagnostic.h:
+	// vector< map< string,vector<double> > > val;
+	// here we use (just keeping data for a single harmonic field):
+	map< string,vector<double> > results;
 
-    /*** setup data structures for diagnostics data, code from Diagnostic::init in Diagnostic.cpp ***/
+	FilterDiagnostics filter;
+	const int nz=2;
+	for(auto const &tag: pdfh->getTags(filter)) {
+		int size = nslice*nz;
+		results[tag.first].resize(size);
+	}
+
+	/*** NOW, run the diagnostics code ***/
+	for(int iz=0; iz<nz; iz++)
+	{
+		for(int ifld=0; ifld<fields->size(); ifld++) {
+			/* this calls the code provided by the plugin, so put breakpoints there if needed */
+			pdfh->getValues(fields->at(ifld), results, iz);
+		}
+	}
+
+	cout << "**********************************" << endl;
+	cout << "Dumping generated diagnostics data" << endl;
+	dump_results(results);
     
-    // Remark on data organization:
-    // in Diagnostic.h:
-    // vector< map< string,vector<double> > > val;
-    // here we use:
-    map< string,vector<double> > results;
+	/*** TODO: clean up all resources, unload the plugin module etc. ***/
 
-    FilterDiagnostics filter;
-    const int nz=2;
-    for(auto const &tag: pdfh->getTags(filter)) {
-        int size = nslice*nz;
-        results[tag.first].resize(size);
-    }
-
-    /*** NOW, run the diagnostics code ***/
-    for(int iz=0; iz<nz; iz++)
-    {
-        for(int ifld=0; ifld<fields->size(); ifld++) {
-            /* this calls the code provided by the plugin, so put breakpoints there if needed */
-            pdfh->getValues(fields->at(ifld), results, iz);
-        }
-    }
-
-    cout << "**********************************" << endl;
-    cout << "Dumping generated diagnostics data" << endl;
-    dump_results(results);
-    
-    /*** TODO: clean up all resources, unload the plugin module etc. ***/
-
-    MPI_Finalize();
+	MPI_Finalize();
 	return(0);
 }

--- a/misc/plugin_testbench/g4_tb.cpp
+++ b/misc/plugin_testbench/g4_tb.cpp
@@ -79,15 +79,14 @@ void dump_result_mtx(ostream& os, const vector<double>& d, const int nz, const i
 }
 void dump_results_core(ostream &os, const map< string,vector<double> >& r, const int nz, const int nslice)
 {
-	int counter = 1; // counter to have unique object names
-	for(auto const &obj: r) {
+	os << "# create empty Python dictionary" << endl;
+	os << "data = {};" << endl;
+	for(auto const &[name,data]: r) {
 		// formatting of data matrix optimized for numpy.array
-		os << "# data in \"" << obj.first << "\"" << endl;
-		os << "data" << counter << " = np.array([" << endl;
-		dump_result_mtx(os, obj.second, nz, nslice);
+		os << "# data in \"" << name << "\"" << endl;
+		os << "data['" << name << "'] = np.array([" << endl;
+		dump_result_mtx(os, data, nz, nslice);
 		os << "])" << endl << endl;
-
-		counter++;
 	}
 }
 void dump_results(ostream &os, TB_Cfg *ptbcfg, const map< string,vector<double> >& r)
@@ -190,6 +189,11 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 	string fncfg(argv[1]);
+
+	if(0==rank) {
+		cout << "name of configuration file: " << fncfg << endl
+		     << "mpisize = " << mpisize << endl << endl;
+	}
 
 	/* prepare the configuration parameters */
 	TB_Cfg *ptbcfg = new TB_Cfg;

--- a/misc/plugin_testbench/g4_tb.cpp
+++ b/misc/plugin_testbench/g4_tb.cpp
@@ -115,10 +115,13 @@ int main(int argc, char **argv)
 	if(rank==0) {
 		cout << "opened config file '" << fncfg << "." << endl;
 	}
-	ptbcfg->update_from_stream(ifs);
+	bool parse_ok=ptbcfg->update_from_stream(ifs);
 	ifs.close();
 	if(rank==0) {
-		cout << "processed config file." << endl << endl;
+		if(!parse_ok)
+			cout << "processed config file (there were errors)." << endl << endl;
+		else
+			cout << "processed config file." << endl << endl;
 	}
 
 
@@ -195,13 +198,15 @@ int main(int argc, char **argv)
 			pdfh->getValues(fields->at(ifld), results, iz);
 		}
 
-		// scale the field for the test
+#if 0
+		// scale the field for test of data organization
 		for (int j=0; j<ptbcfg->nslice; j++) {
 			for (int k=0; k<ptbcfg->ngrid*ptbcfg->ngrid;k++){
 				const int idx=0;
 				fields->at(idx)->field[j].at(k)*=2.0; 
 			}
 		}
+#endif
 	}
 
 	if(0==rank) {

--- a/misc/plugin_testbench/g4_tb_util.cpp
+++ b/misc/plugin_testbench/g4_tb_util.cpp
@@ -1,3 +1,8 @@
+/*
+ * Helper functions for plugin testbench.
+ *
+ * Christoph Lechner, European XFEL, 2024-Apr.
+ */
 #include <fstream>
 #include <iostream>
 #include <cstdio>

--- a/misc/plugin_testbench/g4_tb_util.cpp
+++ b/misc/plugin_testbench/g4_tb_util.cpp
@@ -82,6 +82,7 @@ bool TB_Cfg::update_param(const string key, const string value)
 
 bool TB_Cfg::update_from_stream(ifstream& ifs)
 {
+	bool ok=true;
 	int lcntr=1;
 	string linebuf;
 	while(getline(ifs, linebuf)) {
@@ -96,11 +97,13 @@ bool TB_Cfg::update_from_stream(ifstream& ifs)
 		eat_whitespaces(right);
 		// cout << "L:" << left << ", R:" << right << endl;
 		if(!update_param(left,right)) {
+			// parsing of this parameter-value combination did not work -> report and continue
 			cout << "line " << lcntr << ": error processing parameter " << left << endl;
+			ok = false;
 		}
 
 		lcntr++;
 	}
 
-	return(true);
+	return(ok);
 }

--- a/misc/plugin_testbench/g4_tb_util.cpp
+++ b/misc/plugin_testbench/g4_tb_util.cpp
@@ -80,11 +80,8 @@ bool TB_Cfg::update_param(const string key, const string value)
 	return(false);
 }
 
-bool TB_Cfg::update_from_stream(void)
+bool TB_Cfg::update_from_stream(ifstream& ifs)
 {
-	ifstream ifs;
-
-	ifs.open("demo_params.txt", ifstream::in);
 	int lcntr=1;
 	string linebuf;
 	while(getline(ifs, linebuf)) {
@@ -97,14 +94,13 @@ bool TB_Cfg::update_from_stream(void)
 		string right = linebuf.substr(pos+1,string::npos);
 		eat_whitespaces(left);
 		eat_whitespaces(right);
-		cout << "L:" << left << ", R:" << right << endl;
+		// cout << "L:" << left << ", R:" << right << endl;
 		if(!update_param(left,right)) {
 			cout << "line " << lcntr << ": error processing parameter " << left << endl;
 		}
 
 		lcntr++;
 	}
-	ifs.close();
 
 	return(true);
 }

--- a/misc/plugin_testbench/g4_tb_util.cpp
+++ b/misc/plugin_testbench/g4_tb_util.cpp
@@ -1,0 +1,6 @@
+#include "g4_tb_util.h"
+
+using namespace std;
+
+TB_Cfg::TB_Cfg() {
+}

--- a/misc/plugin_testbench/g4_tb_util.cpp
+++ b/misc/plugin_testbench/g4_tb_util.cpp
@@ -86,6 +86,11 @@ bool TB_Cfg::update_from_stream(ifstream& ifs)
 	int lcntr=1;
 	string linebuf;
 	while(getline(ifs, linebuf)) {
+		eat_whitespaces(linebuf);
+		// Ignore empty lines and comments beginning with '#' sign
+		if((linebuf.length()==0) || (linebuf.at(0)=='#'))
+			continue;
+
 		size_t pos = linebuf.find_first_of("=");
 		if (pos==string::npos) {
 			cout << "line " << lcntr << ": error parsing line \"" << linebuf << "\"" << endl;
@@ -96,6 +101,7 @@ bool TB_Cfg::update_from_stream(ifstream& ifs)
 		eat_whitespaces(left);
 		eat_whitespaces(right);
 		// cout << "L:" << left << ", R:" << right << endl;
+
 		if(!update_param(left,right)) {
 			// parsing of this parameter-value combination did not work -> report and continue
 			cout << "line " << lcntr << ": error processing parameter " << left << endl;

--- a/misc/plugin_testbench/g4_tb_util.cpp
+++ b/misc/plugin_testbench/g4_tb_util.cpp
@@ -1,6 +1,110 @@
+#include <fstream>
+#include <iostream>
+#include <cstdio>
+#include <string>
+#include <map>
+
 #include "g4_tb_util.h"
 
 using namespace std;
 
-TB_Cfg::TB_Cfg() {
+TB_Cfg::TB_Cfg() { }
+
+void TB_Cfg::eat_whitespaces(string& s)
+{
+	const char *ws = " \t";
+	size_t startpos = s.find_first_not_of(ws);
+	size_t endpos   = s.find_last_not_of(ws);
+	if ((startpos==string::npos) || (endpos==string::npos)) {
+		s = "";
+		return;
+	}
+	s = s.substr(startpos, endpos-startpos+1);
+}
+
+bool TB_Cfg::update_param(const string key, const string value)
+{
+	const map<string, double *> param_double {
+		{"dgrid",  &dgrid},
+		{"lambda", &lambda},
+		{"power",  &power},
+		{"w0",     &w0}
+	};
+	const map<string, int *> param_int {
+		{"nslice", &nslice},
+		{"nz",     &nz},
+		{"ngrid",  &ngrid}
+	};
+	const map<string, string *> param_string {
+		{"libfile",   &libfile},
+		{"parameter", &parameter}
+	};
+
+	/* PARAMETERS WITH EXPECTED VALUE OF TYPE 'double' */
+	auto end_d = param_double.end();
+	auto ele_d = param_double.find(key);
+	if(ele_d!=end_d) {
+		double *pd = ele_d->second;
+		int r = sscanf(value.c_str(), "%lg", pd);
+		if(r==0) {
+			cout << "unable to parse value assigned to parameter " << key << endl;
+			return(false);
+		}
+		return(true);
+	}
+
+	/* ... 'int' */
+	auto end_i = param_int.end();
+	auto ele_i = param_int.find(key);
+	if(ele_i!=end_i) {
+		int *pi = ele_i->second;
+		int r = sscanf(value.c_str(), "%d", pi);
+		if(r==0) {
+			cout << "unable to parse value assigned to parameter " << key << endl;
+			return(false);
+		}
+		return(true);
+	}
+
+	/* ... 'string' */
+	auto end_s = param_string.end();
+	auto ele_s = param_string.find(key);
+	if(ele_s!=end_s) {
+		string *ps = ele_s->second;
+		*ps = value;
+		return(true);
+	}
+
+	/* unknown parameter */
+	cout << "unknown parameter " << key << endl;
+	return(false);
+}
+
+bool TB_Cfg::update_from_stream(void)
+{
+	ifstream ifs;
+
+	ifs.open("demo_params.txt", ifstream::in);
+	int lcntr=1;
+	string linebuf;
+	while(getline(ifs, linebuf)) {
+		size_t pos = linebuf.find_first_of("=");
+		if (pos==string::npos) {
+			cout << "line " << lcntr << ": error parsing line \"" << linebuf << "\"" << endl;
+			continue;
+		}
+		string left = linebuf.substr(0,pos);
+		string right = linebuf.substr(pos+1,string::npos);
+		eat_whitespaces(left);
+		eat_whitespaces(right);
+		cout << "L:" << left << ", R:" << right << endl;
+		if(!update_param(left,right)) {
+			cout << "line " << lcntr << ": error processing parameter " << left << endl;
+		}
+
+		lcntr++;
+	}
+	ifs.close();
+
+	return(true);
 }

--- a/misc/plugin_testbench/g4_tb_util.h
+++ b/misc/plugin_testbench/g4_tb_util.h
@@ -1,11 +1,18 @@
 #ifndef __TB_UTIL_H
 #define __TB_UTIL_H
 
+#include <string>
+
 // class holding the configuration data
 // FIXME: currently everything is public, getter functions need to be implemented
 class TB_Cfg {
 public:
 	TB_Cfg();
+	bool update_from_stream(void);
+
+
+	std::string libfile   {"./libdemo.so"};
+	std::string parameter {""};
 
 	int nslice    {4}; // !number of slices *per* process on the MPI communicator!
 	int nz        {3};
@@ -18,6 +25,10 @@ public:
 
 	double power  {1e6};
 	double w0     {20e-6};
+
+private:
+	bool update_param(const std::string, const std::string);
+	void eat_whitespaces(std::string &);
 };
 
 #endif // __TB_UTIL_H

--- a/misc/plugin_testbench/g4_tb_util.h
+++ b/misc/plugin_testbench/g4_tb_util.h
@@ -1,6 +1,7 @@
 #ifndef __TB_UTIL_H
 #define __TB_UTIL_H
 
+#include <fstream>
 #include <string>
 
 // class holding the configuration data
@@ -8,7 +9,7 @@
 class TB_Cfg {
 public:
 	TB_Cfg();
-	bool update_from_stream(void);
+	bool update_from_stream(std::ifstream&);
 
 
 	std::string libfile   {"./libdemo.so"};

--- a/misc/plugin_testbench/g4_tb_util.h
+++ b/misc/plugin_testbench/g4_tb_util.h
@@ -1,0 +1,23 @@
+#ifndef __TB_UTIL_H
+#define __TB_UTIL_H
+
+// class holding the configuration data
+// FIXME: currently everything is public, getter functions need to be implemented
+class TB_Cfg {
+public:
+	TB_Cfg();
+
+	int nslice    {4}; // !number of slices *per* process on the MPI communicator!
+	int nz        {3};
+	double dgrid  {100e-6};
+	int ngrid     {151};
+	double lambda {1e-10};
+	int sample    {1};
+	double s0     {0};
+	int harm      {1};
+
+	double power  {1e6};
+	double w0     {20e-6};
+};
+
+#endif // __TB_UTIL_H


### PR DESCRIPTION
This test environment for diagnostic plugins (currently only for field analysis) can be used to debug (and also benchmark) the code in diagnostics plugins without having to run a full "GENESIS 1.3" simulation.

Currently, the following steps are performed:
- load diagnostic plugin, as specified by user
- generate Gaussian light field, only with transverse dependency. In the moment loading from `.fld.h5` files is NOT supported (yet)
- call diagnostic plugin with the field data
- write the collected results to a `.txt` file, with formatting suitable for Python (`numpy.array`)

MPI is supported, meaning that you can run the program for instance with `mpirun`. In this case the `.txt` file contains the data collected from all processes.

As described in the README.md file that comes with the code, essential parameters are controlled using a configuration file.