### PR TITLE
check if output directory exists and is writable

### DIFF
--- a/include/Setup.h
+++ b/include/Setup.h
@@ -85,6 +85,8 @@ class Setup: public StringProcessing{
 
  private:
    static void usage();
+   bool check_outputdir(const string &);
+
    string rootname,outputdir,lattice,beamline,partfile,fieldfile;
    double gamma0,lambda0,delz;
    bool one4one,shotnoise;


### PR DESCRIPTION
If the user provides the `outputdir` parameter in `&setup`, now a zero-byte temporary file is generated (and then deleted) in the directory.

This test ensures that the output directory exists and is writable. The simulation stops at the `&setup` block should this test fail. So far, the simulation would proceed with the numerically expensive tracking and only crash when about to generate the first output file.
