### PR TITLE
add warnings related to sequences

### DIFF
--- a/include/SeriesManager.h
+++ b/include/SeriesManager.h
@@ -2,21 +2,22 @@
 // Created by reiche on 4/21/23.
 //
 
-#include <string>
-#include <map>
-
 #ifndef GENESIS_1_3_VERSION4_SERIESMANAGER_H
 #define GENESIS_1_3_VERSION4_SERIESMANAGER_H
+
+#include <string>
+#include <map>
 
 class Sequence;
 
 class SeriesManager {
-    public:
+public:
+	SeriesManager();
         void add(std::string, Sequence *);
         double getElement(std::string);
         bool check(std::string);
-    private:
-
+private:
+        int rank_;
         std::map<std::string,Sequence *> catalogue;
 };
 

--- a/src/Lattice/LatticeParser.cpp
+++ b/src/Lattice/LatticeParser.cpp
@@ -237,25 +237,7 @@ ID *LatticeParser::parseID(int idx,int rank, double zin, SeriesManager *sm)
     bool found=false;
     if (fld.compare("l")==0)    { ele->l=atof(val.c_str());  found=true; };
     if (fld.compare("lambdau")==0){ ele->lambdau=atof(val.c_str()); found=true; };
-#if 0
-    if (fld.compare("aw")==0) {
-      /* determine aw value of this undulator */
-      double this_aw=-1.;
-      string this_aw_refname;
-      // if the value string begins with "@", we assume it is a reference to a sequence
-      this->reference(val, &this_aw, &this_aw_refname);
-      if(!this_aw_refname.empty()) {
-        // we got a reference to a sequence, query it
-        this_aw=sm->getElement(this_aw_refname);
-        if(0==rank) {
-          cout << "*** Ref to series " << this_aw_refname << ", result is: " << this_aw << " ***" << endl;
-        }
-      }
-      ele->aw=this_aw; // atof(val.c_str());
-      found=true;
-    }
-#endif
-    if(extractParameterValue(fld,val,sm,rank, "aw", &ele->aw)) {found=true;}
+    if (extractParameterValue(fld,val,sm,rank, "aw", &ele->aw)) {found=true;}
     if (fld.compare("aw_perp")==0)  { ele->paw=atof(val.c_str()); found=true; };
     if (fld.compare("nwig")==0) { ele->nwig=atof(val.c_str()); found=true; };
     if (fld.compare("kx")==0)   { ele->kx=atof(val.c_str()); found=true; haskx = true;};

--- a/src/Loading/SeriesManager.cpp
+++ b/src/Loading/SeriesManager.cpp
@@ -6,17 +6,42 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <algorithm>
+#include <cctype>
+
+#include <mpi.h>
 
 #include "SeriesManager.h"
 #include "Sequence.h"
 
 using namespace std;
 
-void SeriesManager::add(std::string tag, Sequence *seq){
+SeriesManager::SeriesManager() {
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
+}
+
+void SeriesManager::add(string tag, Sequence *seq)
+{
+    // Inform user if there are upper-case characters in the sequence name
+    // (even if the lattice file contains undulator elements with the
+    // undulator parameter "aw = @AW", the function
+    // LatticeParser::extractParameterValue is called with val="@aw",
+    // this applies for instance to git commit id 3aa7ef8, date: 2024-04-18)
+    bool has_uppercase = any_of(
+        tag.begin(), tag.end(),
+        [](unsigned char c) { return(isupper(c)); });
+    if(has_uppercase && (0==rank_)) {
+        cout << "Info: sequence name " << tag << " contains upper-case characters, this may cause issues" << endl;
+    }
+
+    bool exists = this->check(tag);
+    if((exists) && (0==rank_)) {
+        cout << "Info: sequence with name " << tag << " already defined, replacing it" << endl;
+    }
     catalogue[tag]=seq;
 }
 
-bool SeriesManager::check(std::string tag)
+bool SeriesManager::check(string tag)
 {
     auto end = catalogue.end();
     auto ele = catalogue.find(tag);
@@ -24,12 +49,14 @@ bool SeriesManager::check(std::string tag)
     return exists;
 }
 
-double SeriesManager::getElement(std::string tag){
-
+double SeriesManager::getElement(string tag)
+{
     // check if tag is in the list
     bool exists = this->check(tag);
     if (!exists) {
-        cout << "Cannot find requested series " << tag << endl;
+        if(0==rank_) {
+            cout << "Cannot find requested series " << tag << endl;
+        }
         abort(); // implement good error handling (currently it's developer code)
     }
     auto ele = catalogue.find(tag);


### PR DESCRIPTION
- Warns if sequence is to be replaced by sequence with same (case-sensitive) name
- Warns if sequence name contains any upper-case characters, as these can lead to issues with lattices. For instance if an undulator definition in the lattice file contains `aw = @AW`, a look-up for sequence named "aw" will be done. (So in the process of lattice parsing the letters are converted to lower-case.)