### PR TITLE
for now, disable display of "wall clock time" at end of the program execution

### DIFF
--- a/include/genesis.h
+++ b/include/genesis.h
@@ -5,10 +5,6 @@
 #include <string>
 #include <map>
 
-#include <mpi.h>
-
-using namespace std;
-
-int genmain(string, map<string,string> &,bool);
+int genmain(std::string, std::map<std::string,std::string> &,bool);
 
 #endif

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -18,6 +18,7 @@
 // genesis headerfiles & classes
 //#include "CodeTracing.h"
 
+#include "genesis.h" // prototype of 'genmain'
 #include "Beam.h"
 #include "Field.h"
 #include "EField.h"

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <vector>
 #include <iomanip>
@@ -7,10 +8,8 @@
 #include <cstring>
 #include <ctime>
 
-
 #include <fenv.h>
 #include <signal.h>
-
 #include <mpi.h>
 
 
@@ -55,7 +54,7 @@
 #include "SeriesParser.h"
 #include "SimpleHandshake.h"
 
-#include <sstream>
+
 
 using namespace std;
 
@@ -540,14 +539,17 @@ int genmain (string inputfile, map<string,string> &comarg, bool split) {
         }
 
 
- 	if (rank==0) {
+	if (rank==0)
+	{
+	  // remark, CL, 2024-06-24: calls to clock() give the total processor time spent by the process, *not* the wall clock time
 	  double elapsed_Sec=double(clocknow-clockstart)/CLOCKS_PER_SEC;
 
-      time(&timer);
-      cout << endl<< "Program is terminating..." << endl;
+	  time(&timer);
+	  cout << endl<< "Program is terminating..." << endl;
 	  cout << "Ending Time: " << ctime(&timer);
-	  cout << "Total Wall Clock Time: " << elapsed_Sec << " seconds" << endl;
-      cout << "-------------------------------------" << endl;
+	  // CL, 2024-06-24: disabled for the time being, since calls to clock() give the total processor time spent by the process, *not* the wall clock time
+	  // cout << "Total Wall Clock Time: " << elapsed_Sec << " seconds" << endl;
+	  cout << "-------------------------------------" << endl;
 
 
 	  /* tracing report

--- a/src/Main/mainwrap.cpp
+++ b/src/Main/mainwrap.cpp
@@ -1,19 +1,18 @@
-#include "genesis.h"
-
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <map>
+#include <string>
 
 #include <getopt.h>
+#include <mpi.h>
 
+#include "genesis.h"
 #include "version.h"
-
 
 using namespace std;
 
-// very basic wrapper for genesis. Most of the genesis stuff is moved into genmain.
-#include "hdf5.h"
+
 
 void G4_usage(void)
 {
@@ -54,10 +53,6 @@ int main (int argc, char *argv[])
     int rank;
     MPI_Init(&argc, &argv); //MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &rank); // assign rank to node
-
-//    string filename (argv[argc-1]);  // input file is always last element
-//    map<string,string> arguments;
-//    bool ok=true;
 
     if (rank == 0) {
         VersionInfo vi;
@@ -148,6 +143,7 @@ int main (int argc, char *argv[])
 	}
 
 #if 0
+    /* debug code */
     if(rank==0) {
         cout << endl << "### reporting options ###" << endl;
 
@@ -183,6 +179,5 @@ int main (int argc, char *argv[])
     MPI_Barrier(MPI_COMM_WORLD);
     MPI_Finalize(); // node turned off
 
-    // return 0;
     return(sim_core_result);
 }


### PR DESCRIPTION
Reason: Syscall `clock()` gives the CPU time spent by the process, not the wall clock time. For example, if your process is sleep()-ing for a longer time, this time is not included (as one would expect for a wall clock time display).

Therefore temporarily disabled the output until this is fixed.