### PR TITLE
minor: fix missing include hdf5.h

### DIFF
--- a/src/Main/mainwrap.cpp
+++ b/src/Main/mainwrap.cpp
@@ -6,6 +6,7 @@
 
 #include <getopt.h>
 #include <mpi.h>
+#include <hdf5.h>
 
 #include "genesis.h"
 #include "version.h"


### PR DESCRIPTION
The combination of all merged pull requests resulted in status of `dev` branch that did not compile.

The reason is a missing include of `hdf5.h`, this patch fixes it.