### PR TITLE
fix compiler warnings related to array lengths

### DIFF
--- a/src/IO/Output.cpp
+++ b/src/IO/Output.cpp
@@ -374,7 +374,7 @@ void Output::writeBeamBuffer(Beam *beam)
   this->writeBuffer(gid, "current","A",&beam->cu);
 
   int bh=beam->getBunchingHarmonics();
-  char bgroup[20];
+  char bgroup[32];
   for (int i=1; i<bh;i++){
     sprintf(bgroup,"bunching%d",(i+1));
     this->writeBuffer(gid, bgroup, " ",  &beam->bh[i-1]);

--- a/src/IO/readBeamHDF5.cpp
+++ b/src/IO/readBeamHDF5.cpp
@@ -120,8 +120,8 @@ bool ReadBeamHDF5::readSlice(double s, vector<Particle> *slice, double *current,
 
 
   // get size of data set from slice
-  char name[20];
-  sprintf(name,"slice%6.6d/gamma",islice);
+  char name[32];
+  sprintf(name,"slice%6.6d/gamma",islice); // note by CL, 2024-07-30: consider replacing these by snprintf or stringstream operations
 
   int nsize=getDatasetSize(fid, name);
 


### PR DESCRIPTION
Fixes compiler message reporting potential buffer overflow (reported for example by gcc version `gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0`).

In total two char array lengths were adjusted to address warnings such as:
```
/home/cl/g4/x/Genesis-1.3-Version4/src/IO/readBeamHDF5.cpp:152:27: warning: ‘/theta’ directive writing 6 bytes into a region of size between 4 and 9 [-Wformat-overflow=]
  152 |   sprintf(name,"slice%6.6d/theta",islice);
      |                           ^~~~~~
In file included from /usr/include/stdio.h:894,
                 from /usr/include/c++/11/cstdio:42,
                 from /usr/include/c++/11/ext/string_conversions.h:43,
                 from /usr/include/c++/11/bits/basic_string.h:6608,
                 from /usr/include/c++/11/string:55,
                 from /usr/include/c++/11/bits/locale_classes.h:40,
                 from /usr/include/c++/11/bits/ios_base.h:41,
                 from /usr/include/c++/11/ios:42,
                 from /usr/include/c++/11/ostream:38,
                 from /usr/include/c++/11/iostream:39,
                 from /home/cl/g4/x/Genesis-1.3-Version4/include/readBeamHDF5.h:2,
                 from /home/cl/g4/x/Genesis-1.3-Version4/src/IO/readBeamHDF5.cpp:1:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:38:34: note: ‘__builtin___sprintf_chk’ output between 18 and 23 bytes into a destination of size 20
   38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   39 |                                   __glibc_objsize (__s), __fmt,
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   40 |                                   __va_arg_pack ());
      |                                   ~~~~~~~~~~~~~~~~~
```