### PR TITLE
small additions

### DIFF
--- a/src/Loading/SeriesParser.cpp
+++ b/src/Loading/SeriesParser.cpp
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <vector>
 #include "SeriesParser.h"
-#include "Sequence.h"
+#include "Sequence.h" // contains implementation of several classes
 
 bool SeriesParser::init(int rank, std::map<std::string,std::string> *arg, std::string element, SeriesManager *sm){
     // slit for the different cases

--- a/src/Main/mainwrap.cpp
+++ b/src/Main/mainwrap.cpp
@@ -53,9 +53,13 @@ void G4_report_lib_versions(void)
 {
     int rank;
 
+    // only rank 0 prints infos...
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     if(0!=rank)
         return;
+
+
+    cout << endl; // some whitespace
 
     char buf[MPI_MAX_LIBRARY_VERSION_STRING];
     int bufused=-1;
@@ -81,7 +85,11 @@ void G4_report_lib_versions(void)
     // But there is char fftw_version[] (checked for FFTW v3.3.8)
 #ifdef FFTW
     cout << "FFTW version string: " << fftw_version << endl;
+#else
+    cout << "FFTW version string: not compiled in" << endl;
 #endif
+
+    cout << endl;
 }
 
 int main (int argc, char *argv[])


### PR DESCRIPTION
Just small stuff.

- added info comment: location of class implementations
- debug command line argument `--dbg-versions` now explicitly states if binary was compiled w/o FFTW3