### PR TITLE
DOC: import_distribution settimewindow is by default false

### DIFF
--- a/manual/MAIN_INPUT.md
+++ b/manual/MAIN_INPUT.md
@@ -292,7 +292,7 @@ Note that this namelist will be expanded in the future, to enable tilts and matc
 - `alphay`(*double, 0 or matched value*): If matching is enabled, new alpha function in $y$.
 - `eval_start` (*double, 0*): evaluation start.
 - `eval_end` (*double, 1*): evaluation end.
-- `settimewindow` (*bool, true*): set time window.
+- `settimewindow` (*bool, false*): set time window.
 - `align` (*int, 0*): currently unused.
 - `align_start` (*double, 0*): currently unused.
 - `align_end` (*double, 1*): currently unused.

--- a/src/IO/SDDSBeam.cpp
+++ b/src/IO/SDDSBeam.cpp
@@ -34,7 +34,7 @@ void SDDSBeam::usage(){
   cout << " string file = <empty> " << endl;
   cout << " double charge   = 0 / <distribution file>" << endl;
   cout << " double slicewidth = 0.01" << endl;
-  cout << " bool settimewindow = true" << endl;
+  cout << " bool settimewindow = false" << endl;
   cout << " bool center = false " << endl;
   cout << " double gamma0 = gammaref " << endl;
   cout << " double x0 = 0 " << endl;


### PR DESCRIPTION
`&import_distribution` `settimewindow` is by default false in the codebase, but is noted as default true in the documentation.

Context: for https://github.com/slaclab/lume-genesis/ it's important we have these defaults correct so that the Python classes will be generated appropriately.

A quick check, after the changes in this PR:
```c
$ git grep settime
include/SDDSBeam.h:   bool center,match,settime;
manual/MAIN_INPUT.md:- `settimewindow` (*bool, false*): set time window.
src/IO/SDDSBeam.cpp:  settime=false;
src/IO/SDDSBeam.cpp:  cout << " bool settimewindow = false" << endl;
src/IO/SDDSBeam.cpp:  if (arg->find("settimewindow")!=end)   {settime= atob(arg->at("settimewindow").c_str());arg->erase(arg->find("settimewindow"));}
src/IO/SDDSBeam.cpp:  if (settime){
```

(cc @balticfish)