### PR TITLE
Import field attenuation

### DIFF
--- a/include/ImportField.h
+++ b/include/ImportField.h
@@ -35,6 +35,7 @@ class ImportField : public StringProcessing{
    int harm;
    double offset;
    bool dotime;
+   double attenuation;
 };
 
 

--- a/include/readFieldHDF5.h
+++ b/include/readFieldHDF5.h
@@ -29,6 +29,7 @@ class ReadFieldHDF5 : public HDF5Base {
   int getNGrid();
   double getDGrid();
   double attenuation=1.0;
+  double offset=0.0;
 
  private:
   hid_t fid;

--- a/include/readFieldHDF5.h
+++ b/include/readFieldHDF5.h
@@ -28,7 +28,7 @@ class ReadFieldHDF5 : public HDF5Base {
   void close();
   int getNGrid();
   double getDGrid();
-
+  double attenuation=1.0;
 
  private:
   hid_t fid;

--- a/manual/MAIN_INPUT.md
+++ b/manual/MAIN_INPUT.md
@@ -328,7 +328,9 @@ The modules controls the import of a Genesis 1.3 field file to replace the inter
 
 - `file` (*string, \<empty>*): File name of a hdf5 compliant datafile to contain the slice-wise particle distribution. It has to follow the internal Genesis 1.3 syntax.
 - `harmonic` (*int, 1*) defines the harmonic for the given Genesis run.
-- `time` (*bool, true*): If the time window hasn’t be defined it allows to run Genesis with the imported distribution in scan mode, when set to `false`. This would disable all slippage and long-range collective effects in the simulation
+- `time` (*bool, true*): If the time window hasn’t been defined it allows to run Genesis with the imported distribution in scan mode, when set to `false`. This would disable all slippage and long-range collective effects in the simulation
+- `attenuation` (*double, 1.0): apply an on-the-flight scaling factor to the field to be imported, without the need of modifying the original field file.
+- `offset` (*double, 0*): currently unused.
 
 [Back](#supported-namelists)
 

--- a/manual/MAIN_INPUT.md
+++ b/manual/MAIN_INPUT.md
@@ -329,7 +329,7 @@ The modules controls the import of a Genesis 1.3 field file to replace the inter
 - `file` (*string, \<empty>*): File name of a hdf5 compliant datafile to contain the slice-wise particle distribution. It has to follow the internal Genesis 1.3 syntax.
 - `harmonic` (*int, 1*) defines the harmonic for the given Genesis run.
 - `time` (*bool, true*): If the time window hasn’t been defined it allows to run Genesis with the imported distribution in scan mode, when set to `false`. This would disable all slippage and long-range collective effects in the simulation
-- `attenuation` (*double, 1.0): apply an on-the-flight scaling factor to the field to be imported, without the need of modifying the original field file.
+- `attenuation` (*double, 1.0*): apply an on-the-flight scaling factor to the field to be imported, without the need of modifying the original field file.
 - `offset` (*double, 0*): currently unused.
 
 [Back](#supported-namelists)

--- a/src/IO/readFieldHDF5.cpp
+++ b/src/IO/readFieldHDF5.cpp
@@ -103,7 +103,7 @@ bool ReadFieldHDF5::readSlice(double s, vector<complex<double> >*field){
 
   if(!isOpen){ return false; } // skip if partfile option is not selected
   
-  double rslice=(s-s0)/slicelen;
+  double rslice=(s-s0+offset)/slicelen;
   if (fabs(rslice-round(rslice))>1e-3){ return false; }
   int islice=static_cast<int> (round(rslice))+1;
 

--- a/src/IO/readFieldHDF5.cpp
+++ b/src/IO/readFieldHDF5.cpp
@@ -51,7 +51,7 @@ bool ReadFieldHDF5::readGlobal(int rank, int size,string file, Setup *setup, Tim
 
   double ks=4.*asin(1)/reflen;
   scl=dgrid*eev/ks/sqrt(vacimp);
-  scl=1./scl;
+  scl = 1. / scl * attenuation;
   dgrid=0.5*dgrid*static_cast<double>(ngrid-1);
 
 
@@ -119,13 +119,13 @@ bool ReadFieldHDF5::readSlice(double s, vector<complex<double> >*field){
   sprintf(name,"slice%6.6d/field-real",islice);
   readDataDouble(fid,name,work,nwork);
   for (int i=0;i<nwork;i++){
-    field->at(i)=scl*work[i];
+    field->at(i) = scl * work[i];
   }
 
   sprintf(name,"slice%6.6d/field-imag",islice);
   readDataDouble(fid,name,work,nwork);
   for (int i=0;i<nwork;i++){
-    field->at(i)+=complex<double>(0,scl*work[i]);
+    field->at(i)+=complex<double>(0,scl * work[i]);
   }
 
 

--- a/src/IO/readFieldHDF5.cpp
+++ b/src/IO/readFieldHDF5.cpp
@@ -103,7 +103,8 @@ bool ReadFieldHDF5::readSlice(double s, vector<complex<double> >*field){
 
   if(!isOpen){ return false; } // skip if partfile option is not selected
   
-  double rslice=(s-s0+offset)/slicelen;
+  // double rslice=(s-s0+offset)/slicelen;
+  double rslice=(s-s0)/slicelen;
   if (fabs(rslice-round(rslice))>1e-3){ return false; }
   int islice=static_cast<int> (round(rslice))+1;
 

--- a/src/Loading/ImportField.cpp
+++ b/src/Loading/ImportField.cpp
@@ -7,6 +7,7 @@ ImportField::ImportField()
   offset=0;
   harm=1;
   dotime=true;
+  attenuation=1.0;
 }
 
 ImportField::~ImportField(){}
@@ -17,6 +18,7 @@ void ImportField::usage(){
   cout << "&importfield" << endl;
   cout << " string file = <empty>" << endl;
   cout << " int harmonic = 1" << endl;
+  cout << " double attenuation = 1.0" << endl;
   cout << " bool time = true" << endl;
   cout << "&end" << endl << endl;
   return;
@@ -37,7 +39,7 @@ bool ImportField::init(int rank, int size, map<string,string> *arg, vector<Field
   if (arg->find("file")!=end    ){file=arg->at("file"); arg->erase(arg->find("file"));}
   if (arg->find("time")!=end)    {dotime = atob(arg->at("time").c_str()); arg->erase(arg->find("time"));}
   if (arg->find("harmonic")!=end){harm = atoi(arg->at("harmonic").c_str()); arg->erase(arg->find("harmonic"));}
-
+  if (arg->find("attenuation")!=end)  {attenuation = atof(arg->at("attenuation").c_str()); arg->erase(arg->find("attenuation"));}
 
   if (arg->size()!=0){
     if (rank==0){ cout << "*** Error: Unknown elements in &importfield" << endl; this->usage();}
@@ -47,6 +49,7 @@ bool ImportField::init(int rank, int size, map<string,string> *arg, vector<Field
 
 
   ReadFieldHDF5 import;
+  import.attenuation = attenuation;
 
   bool check=import.readGlobal(rank, size, file, setup, time, harm, dotime);
   if (!check) { 

--- a/src/Loading/ImportField.cpp
+++ b/src/Loading/ImportField.cpp
@@ -40,6 +40,7 @@ bool ImportField::init(int rank, int size, map<string,string> *arg, vector<Field
   if (arg->find("time")!=end)    {dotime = atob(arg->at("time").c_str()); arg->erase(arg->find("time"));}
   if (arg->find("harmonic")!=end){harm = atoi(arg->at("harmonic").c_str()); arg->erase(arg->find("harmonic"));}
   if (arg->find("attenuation")!=end)  {attenuation = atof(arg->at("attenuation").c_str()); arg->erase(arg->find("attenuation"));}
+  if (arg->find("offset")!=end)  {attenuation = atof(arg->at("offset").c_str()); arg->erase(arg->find("offset"));}
 
   if (arg->size()!=0){
     if (rank==0){ cout << "*** Error: Unknown elements in &importfield" << endl; this->usage();}
@@ -50,6 +51,7 @@ bool ImportField::init(int rank, int size, map<string,string> *arg, vector<Field
 
   ReadFieldHDF5 import;
   import.attenuation = attenuation;
+  import.offset = offset;
 
   bool check=import.readGlobal(rank, size, file, setup, time, harm, dotime);
   if (!check) { 

--- a/src/Loading/ImportField.cpp
+++ b/src/Loading/ImportField.cpp
@@ -40,7 +40,7 @@ bool ImportField::init(int rank, int size, map<string,string> *arg, vector<Field
   if (arg->find("time")!=end)    {dotime = atob(arg->at("time").c_str()); arg->erase(arg->find("time"));}
   if (arg->find("harmonic")!=end){harm = atoi(arg->at("harmonic").c_str()); arg->erase(arg->find("harmonic"));}
   if (arg->find("attenuation")!=end)  {attenuation = atof(arg->at("attenuation").c_str()); arg->erase(arg->find("attenuation"));}
-  if (arg->find("offset")!=end)  {offset = atof(arg->at("offset").c_str()); arg->erase(arg->find("offset"));}
+  // if (arg->find("offset")!=end)  {offset = atof(arg->at("offset").c_str()); arg->erase(arg->find("offset"));}
 
   if (arg->size()!=0){
     if (rank==0){ cout << "*** Error: Unknown elements in &importfield" << endl; this->usage();}
@@ -51,7 +51,8 @@ bool ImportField::init(int rank, int size, map<string,string> *arg, vector<Field
 
   ReadFieldHDF5 import;
   import.attenuation = attenuation;
-  import.offset = offset;
+  // deactivated
+  // import.offset = offset;
 
   bool check=import.readGlobal(rank, size, file, setup, time, harm, dotime);
   if (!check) { 

--- a/src/Loading/ImportField.cpp
+++ b/src/Loading/ImportField.cpp
@@ -40,7 +40,7 @@ bool ImportField::init(int rank, int size, map<string,string> *arg, vector<Field
   if (arg->find("time")!=end)    {dotime = atob(arg->at("time").c_str()); arg->erase(arg->find("time"));}
   if (arg->find("harmonic")!=end){harm = atoi(arg->at("harmonic").c_str()); arg->erase(arg->find("harmonic"));}
   if (arg->find("attenuation")!=end)  {attenuation = atof(arg->at("attenuation").c_str()); arg->erase(arg->find("attenuation"));}
-  if (arg->find("offset")!=end)  {attenuation = atof(arg->at("offset").c_str()); arg->erase(arg->find("offset"));}
+  if (arg->find("offset")!=end)  {offset = atof(arg->at("offset").c_str()); arg->erase(arg->find("offset"));}
 
   if (arg->size()!=0){
     if (rank==0){ cout << "*** Error: Unknown elements in &importfield" << endl; this->usage();}

--- a/src/Loading/ImportField.cpp
+++ b/src/Loading/ImportField.cpp
@@ -80,6 +80,7 @@ bool ImportField::init(int rank, int size, map<string,string> *arg, vector<Field
   if (idx<0){
     field=new Field;
     if (rank==0) {cout << "Importing radiation field distribution from file: " << file << " ..." << endl; }
+    if (rank==0) {cout << "Using attenuation: " << attenuation << " and offset " << offset << endl; }
   } else {
     if (rank==0) {cout << "*** Error: Cannot import field, because field is already defined" << endl; }
     return false;


### PR DESCRIPTION
I implemented an attenuation factor for the field import element. This allows for importing and scaling field files without the need of modifying or creating copies of large hdf5 files.
The manual has also been updated to reflect the change.