### PR TITLE
Add support of sequence using in definition of chicane delay

### DIFF
--- a/include/LatticeParser.h
+++ b/include/LatticeParser.h
@@ -27,7 +27,7 @@ class LatticeParser : public StringProcessing {
    Quadrupole *parseQuad(int,int,double);
    Drift *parseDrift(int,int,double);
    Marker *parseMarker(int,int,double);
-   Chicane *parseChicane(int,int,double);
+   Chicane *parseChicane(int,int,double, SeriesManager *);
    Corrector *parseCorrector(int,int,double);
    ID *parseID(int,int,double, SeriesManager *);
    Phaseshifter *parsePhaseshifter(int,int,double, SeriesManager *);

--- a/src/Lattice/LatticeParser.cpp
+++ b/src/Lattice/LatticeParser.cpp
@@ -228,7 +228,7 @@ bool LatticeParser::parse(string file, string line, int rank, vector<Element *> 
     if (type[idx].compare("undu")==0){ error=false; lat.push_back(this->parseID(idx,rank,z,sm)); }
     if (type[idx].compare("drif")==0){ error=false; lat.push_back(this->parseDrift(idx,rank,z));}
     if (type[idx].compare("corr")==0){ error=false; lat.push_back(this->parseCorrector(idx,rank,z));}
-    if (type[idx].compare("chic")==0){ error=false; lat.push_back(this->parseChicane(idx,rank,z)); }
+    if (type[idx].compare("chic")==0){ error=false; lat.push_back(this->parseChicane(idx,rank,z,sm)); }
     if (type[idx].compare("mark")==0){ error=false; lat.push_back(this->parseMarker(idx,rank,z)); }
     if (type[idx].compare("phas")==0){ error=false; lat.push_back(this->parsePhaseshifter(idx,rank,z,sm)); }
     if (error) { 
@@ -376,7 +376,7 @@ Corrector *LatticeParser::parseCorrector(int idx,int rank, double zin)
 }
 
 
-Chicane *LatticeParser::parseChicane(int idx,int rank, double zin)
+Chicane *LatticeParser::parseChicane(int idx,int rank, double zin, SeriesManager *sm)
 {
   Chicane *ele=new Chicane;
 
@@ -405,7 +405,7 @@ Chicane *LatticeParser::parseChicane(int idx,int rank, double zin)
     this->trim(fld);
     bool found=false;
     if (fld.compare("l")==0)    { ele->l=atof(val.c_str());  found=true; };
-    if (fld.compare("delay")==0){ ele->delay=atof(val.c_str()); found=true; };
+    if (extractParameterValue(fld,val,sm,rank, "delay", &ele->delay)){ found=true; };
     if (fld.compare("lb")==0)   { ele->lb=atof(val.c_str()); found=true; };
     if (fld.compare("ld")==0)   { ele->ld=atof(val.c_str()); found=true; };
     if (found==false){


### PR DESCRIPTION
This is useful for simulating continuous inter-undulator slippage, such as the prime sequence slippage of HB-SASE