### PR TITLE
CI: build Genesis4 on GitHub Actions (system libraries, conda)

### DIFF
--- a/.github/genesis4-build-env-mpich.yaml
+++ b/.github/genesis4-build-env-mpich.yaml
@@ -1,0 +1,10 @@
+# conda env create -f .github/genesis4-build-env-mpich.yml
+name: genesis4-build-mpich
+channels:
+  - conda-forge
+dependencies:
+  - compilers
+  - cmake
+  - fftw * mpi_mpich*
+  - hdf5 * mpi_mpich*
+  - mpich

--- a/.github/genesis4-build-env-openmpi.yaml
+++ b/.github/genesis4-build-env-openmpi.yaml
@@ -1,0 +1,10 @@
+# conda env create -f .github/genesis4-build-env-mpich.yml
+name: genesis4-build-openmpi
+channels:
+  - conda-forge
+dependencies:
+  - compilers
+  - cmake
+  - fftw * mpi_openmpi*
+  - hdf5 * mpi_openmpi*
+  - openmpi

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -xe
+
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Wextra $CMAKE_CXX_FLAGS"
+make -C build
+
+ls -la build/genesis4

--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+output=$(./build/genesis4)
+if [[ "$output" != *"Usage: genesis4"* ]]; then
+  echo "Error: Expected 'Usage: genesis4' in output but got: $output"
+  exit 1
+else
+  echo "Genesis4 seems to have built correctly; 'usage' found in output."
+fi
+
+# TODO: insert some actual tests here

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,88 @@
+name: Genesis4 - System Libraries Build & Test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-system:
+    name: system-${{ matrix.os }}-${{ matrix.mpi }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            mpi: openmpi
+          - os: ubuntu-latest
+            mpi: mpich
+          - os: macos-latest
+            mpi: openmpi
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies (Ubuntu) - OpenMPI
+        if: runner.os == 'Linux' && matrix.mpi == 'openmpi'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            pkg-config \
+            cmake \
+            libfftw3-mpi-dev \
+            libhdf5-openmpi-dev \
+            libopenmpi-dev \
+            openmpi-bin
+
+      - name: Install system dependencies (Ubuntu) - MPICH
+        if: runner.os == 'Linux' && matrix.mpi == 'mpich'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            pkg-config \
+            cmake \
+            libfftw3-mpi-dev \
+            libhdf5-mpich-dev \
+            libmpich-dev \
+            mpich
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install \
+            cmake \
+            gcc \
+            fftw \
+            hdf5-mpi \
+            ${{ matrix.mpi }}
+
+      - name: Setup MPI environment
+        run: |
+          which mpicc
+          which mpicxx
+          which h5pcc
+          mpicc --version
+          mpicxx --version
+
+      - name: Build Genesis4
+        env:
+          MPI: ${{ matrix.mpi }}
+        shell: bash -eo pipefail -l {0}
+        run: .github/scripts/build.sh
+
+      - name: Upload Genesis4 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: genesis4-${{ matrix.os }}-${{ matrix.mpi }}-system
+          path: build/genesis4
+
+      - name: Run tests
+        run: |
+          .github/scripts/run_tests.sh 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,0 +1,49 @@
+name: Genesis4 - Conda Build & Test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-conda:
+    name: conda-${{ matrix.os }}-${{ matrix.mpi }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        mpi: [openmpi, mpich]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          use-mamba: true
+          activate-environment: genesis4-build
+          channels: conda-forge
+          environment-file: .github/genesis4-build-env-${{ matrix.mpi }}.yaml
+          python-version: 3.12
+          conda-remove-defaults: true
+
+      - name: Build Genesis4 with Conda
+        env:
+          MPI: ${{ matrix.mpi }}
+        shell: bash -eo pipefail -l {0}
+        run: .github/scripts/build.sh
+
+      - name: Upload Genesis4 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: genesis4-${{ matrix.os }}-${{ matrix.mpi }}-conda
+          path: build/genesis4
+
+      - name: Run tests
+        shell: bash -eo pipefail -l {0}
+        run: .github/scripts/run_tests.sh 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,8 @@ set(CMAKE_CXX_EXTENTIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 # set(CMAKE_INSTALL_RPATH "/usr/local/lib")
-set(CMAKE_CXX_FLAGS -lstdc++)
-#set(CMAKE_CXX_FLAGS '-lstdc++ -Wall -Wextra')
-#set(CMAKE_CXX_FLAGS '-g')
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 
 # developer options
 set(CMAKE_VERBOSE_MAKEFILE ON)
@@ -199,4 +198,4 @@ add_dependencies(genesis13 get_git_hash)
 
 add_executable(genesis4 src/Main/mainwrap.cpp)
 
-target_link_libraries(genesis4 genesis13 ${_libraries})
+target_link_libraries(genesis4 genesis13 stdc++ ${_libraries})


### PR DESCRIPTION
## Overview

This PR adds GitHub Actions building of `genesis4` with both system-level and Conda-based builds across Linux/MacOS and OpenMPI/MPICH.

There are also a couple tweaks to the `CMakeLists.txt` to avoid overwriting the environment CXXFLAGS (instead using CMake features to explicitly link `stdc++`).

### New files

* `.github/workflows/build.yaml` definse a GitHub Actions workflow for system-level builds and tests, supporting Ubuntu and macOS with OpenMPI and MPICH.
* `.github/workflows/conda-build.yml` defines a GitHub Actions workflow for Conda-based builds and tests, supporting Ubuntu and macOS with OpenMPI and MPICH.
* `.github/scripts/build.sh` - a shared build script for conda/system libraries.
*  `.github/scripts/run_tests.sh` performs basic validation of the built Genesis4 binary by checking its `usage` output. This is really just a placeholder - something better should be added.
* `.github/*build-env*.yaml` are conda environment files required for the conda-based builds