### PR TITLE
Fix singleWakeResistive to reproduce SLAC-PUB-10707 wakefields.

### DIFF
--- a/src/Main/Wake.cpp
+++ b/src/Main/Wake.cpp
@@ -278,7 +278,7 @@ void Wake::singleWakeGeometric(int rank)
  *   • Final: multiply by (−e) once (converts V/C to signed energy-kick units for electrons).
  *
  * Implementation notes:
- *   • Prints "k  Re(Zk)  Im(Zk)" on rank==0 for quick cross-checks; comment out later.
+ *   • Commented out "k  Re(Zk)  Im(Zk)" and "z Wz" on rank==0 for quick cross-checks, 
  *   • Tunables: KAPPA_MAX, NK (k-grid); XMAX, NQ (flat x-integral).
  */
 void Wake::singleWakeResistive(int rank)
@@ -385,14 +385,14 @@ void Wake::singleWakeResistive(int rank)
             const double k = ks[j];
             const cd Z = Zk_round(k);
             ReZ[j] = Z.real();
-            if (rank == 0) std::cout << k << " " << Z.real() << " " << Z.imag() << "\n";
+            //if (rank == 0) std::cout << k << " " << Z.real() << " " << Z.imag() << "\n";
         }
     } else {
         for (unsigned int j = 0; j <= NK; ++j) {
             const double k = ks[j];
             const cd Z = Zk_flat(k);
             ReZ[j] = Z.real();
-            if (rank == 0) std::cout << k << " " << Z.real() << " " << Z.imag() << "\n";
+            //if (rank == 0) std::cout << k << " " << Z.real() << " " << Z.imag() << "\n";
         }
     }
 
@@ -410,10 +410,26 @@ void Wake::singleWakeResistive(int rank)
             acc += ReZ[j] * std::cos(ks[j] * s_i);
         }
         wakeres[i] = acc * cos_pref;                   // V/C
+        //if (rank == 0) std::cout << std::setprecision(16) << (i * ds) << " " << wakeres[i] << '\n';
+
     }
 
     // ---- Final conversion: V/C → signed energy kick (electron sign) ----
     for (int i = 0; i < ns; ++i) wakeres[i] *= -e_charge;
+
+
+    // Debug print to file
+    if (rank == 0) {
+        std::ofstream out("Wz.txt");           // use std::ios::app to append
+        out << std::setprecision(16);
+        for (int i = 0; i < ns; ++i) {
+            const double z = i * ds;
+            out << z << " " << wakeres[i] << '\n';   // z [m], W(z) (after −e scaling)
+        }
+        // out.close(); // optional; destructor closes automatically
+    }
+    
+
 
     if (rank == 0) {
         std::cout << "Resistive Wake (" << (roundpipe ? "ROUND" : "FLAT")


### PR DESCRIPTION
This is a drop-in replacement for Wake::singleWakeResistive that reproduces SLAC-PUB-10707 wakefields.

Developed with the help of ChatGPT o3.

This addresses https://github.com/svenreiche/Genesis-1.3-Version4/issues/231. With those parameters, the integrated Wakefield looks like:

<img width="513" height="349" alt="image" src="https://github.com/user-attachments/assets/c82f16fe-9a79-490c-b4ba-ff8c38c75c2e" />

with `-70 keV` average energy change


## Benchmarking
The code includes a block that writes `Wz.txt` for debugging. This shows excellent  agreement with the LCLS case in SLAC-PUB-10707. Complete code:


```python
import numpy as np
from scipy.constants import epsilon_0, e
import matplotlib.pyplot as plt

GEOMETRY = 'flat'

# Genesis4 debug data
z, Wz = np.loadtxt(f'Wz_{GEOMETRY}.txt').T

# SLAC-PUB digitized data
if GEOMETRY == 'round':
    file = "SLAC-PUB-10707-digitized-Fig4-AC-Cu.csv"
elif GEOMETRY == 'flat':
    file = "SLAC-PUB-10707-digitized-Fig8-AC-Cu.csv"
raw_data = np.loadtxt(file, delimiter=",")
radius_ref = 2.5e-3 # m
# Convert to SI
zref, Wref = (
    raw_data[:, 0] * 1e-6,
    raw_data[:, 1] * 4 / radius_ref**2 / (4 * np.pi * epsilon_0),
)

fig, ax = plt.subplots()
ax.plot(zref*1e6, Wref * 1e-15, label=file)
ax.plot(z*1e6, -Wz/e * 1e-15, '--', label=f'Genesis4 PR #233 ({GEOMETRY})')
ax.legend()
ax.set_ylabel(r'$W_z$ (V/pC/m)')
ax.set_xlabel(r'$-z$ (µm)')
plt.savefig(f'genesis4_resistive_wall_benchmark_{GEOMETRY}.png', dpi = 150, bbox_inches='tight')
```
<img width="851" height="651" alt="genesis4_resistive_wall_benchmark_flat" src="https://github.com/user-attachments/assets/368a4d64-3591-4c82-b649-e36f7b288256" />
<img width="851" height="651" alt="genesis4_resistive_wall_benchmark_round" src="https://github.com/user-attachments/assets/baca917e-987f-4d4d-9142-fc14dcf1933b" />


Data:

[SLAC-PUB-10707-digitized-Fig4-AC-Cu.csv](https://github.com/user-attachments/files/21643088/SLAC-PUB-10707-digitized-Fig4-AC-Cu.csv)


[SLAC-PUB-10707-digitized-Fig8-AC-Cu.csv](https://github.com/user-attachments/files/21668424/SLAC-PUB-10707-digitized-Fig8-AC-Cu.csv)
[Wz_flat.txt](https://github.com/user-attachments/files/21668431/Wz_flat.txt)


[Wz_round.txt](https://github.com/user-attachments/files/21668433/Wz_round.txt)

## Genesis 4 input

```
&setup
  rootname = SLAC-PUB-10707
  lattice = genesis.lat
  beamline = LAT
  gamma0 = 27397.316532834073
  lambda0 = 1e-07
  seed = 123456
  npart = 128
&end

&time
  slen = 0.0002
&end

&profile_gauss
  label = beamcurrent
  c0 = 5979.994342083536
  s0 = 0.0001
  sig = 2e-05
&end

&beam
  gamma = 27397.316532834073
  delgam = 0.0001
  current = @beamcurrent
&end

&wake
  roundpipe = false
  conductivity = 65000000.0
  relaxation = 8.094396366e-06
&end

&write
  beam = beginning
&end

&track
  zstop = 1.0
&end

&write
  beam = end
&end
```

with `genesis.lat`:
```
D1: drift = {l=1.0};
LAT: LINE = {D1};
```