### PR TITLE
add tests for G4 build process with diagnostic plugins

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+# for test of diagnostic plugin interface (DPI), available only on Linux
+ARG_DPI=""
+if [ ! -z "$WITH_DPI" ] ; then
+	echo x
+	ARG_DPI="-DUSE_DPI=1"
+fi
+
 set -xe
 
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Wextra $CMAKE_CXX_FLAGS"
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release $ARG_DPI -DCMAKE_CXX_FLAGS="-Wall -Wextra $CMAKE_CXX_FLAGS"
 make -C build
 
 ls -la build/genesis4

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -3,7 +3,6 @@
 # for test of diagnostic plugin interface (DPI), available only on Linux
 ARG_DPI=""
 if [ ! -z "$WITH_DPI" ] ; then
-	echo x
 	ARG_DPI="-DUSE_DPI=1"
 fi
 

--- a/.github/workflows/build_dpi.yaml
+++ b/.github/workflows/build_dpi.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-system:
-    name: system-${{ matrix.os }}-${{ matrix.mpi }}
+    name: system-dpi-${{ matrix.os }}-${{ matrix.mpi }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -62,13 +62,13 @@ jobs:
           mpicc --version
           mpicxx --version
 
-      - name: Build Genesis4
+      - name: Build Genesis4 (with DPI)
         env:
           MPI: ${{ matrix.mpi }}
           WITH_DPI: 1
         shell: bash -eo pipefail -l {0}
         run: .github/scripts/build.sh
 
-      - name: Run tests
+      - name: Run tests (with DPI)
         run: |
           .github/scripts/run_tests.sh 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build_dpi.yaml
+++ b/.github/workflows/build_dpi.yaml
@@ -1,0 +1,74 @@
+name: Genesis4 - System Libraries Build & Test (diagnostic plugins)
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+# Based on build.yaml from commit id bbed450 (Aug 6, 2025).
+# As of 2025-Aug, diagnostic plugins are only available on the Linux platform
+# -> kicking out all macos stuff
+
+jobs:
+  build-system:
+    name: system-${{ matrix.os }}-${{ matrix.mpi }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            mpi: openmpi
+          - os: ubuntu-latest
+            mpi: mpich
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies (Ubuntu) - OpenMPI
+        if: runner.os == 'Linux' && matrix.mpi == 'openmpi'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            pkg-config \
+            cmake \
+            libfftw3-mpi-dev \
+            libhdf5-openmpi-dev \
+            libopenmpi-dev \
+            openmpi-bin
+
+      - name: Install system dependencies (Ubuntu) - MPICH
+        if: runner.os == 'Linux' && matrix.mpi == 'mpich'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            pkg-config \
+            cmake \
+            libfftw3-mpi-dev \
+            libhdf5-mpich-dev \
+            libmpich-dev \
+            mpich
+
+      - name: Setup MPI environment
+        run: |
+          which mpicc
+          which mpicxx
+          which h5pcc
+          mpicc --version
+          mpicxx --version
+
+      - name: Build Genesis4
+        env:
+          MPI: ${{ matrix.mpi }}
+          WITH_DPI: 1
+        shell: bash -eo pipefail -l {0}
+        run: .github/scripts/build.sh
+
+      - name: Run tests
+        run: |
+          .github/scripts/run_tests.sh 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
To curb resource utilization, it is compiled only for Linux and only using one of the two build methods