### PR TITLE
CI: simple analysis of test simulation

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -20,7 +20,7 @@ G4=`realpath ./build/genesis4`
 # Run test case ('Example1-SteadyState': steady-state simulation, completes in approx 10s on CL's desktop PC)
 #
 # Currently this tests only for successful completion (the output itself
-# is not analyzed).
+# is analyzed in the next step).
 ###
 SEMAFILE="testrun.sema"
 RUNDIR="./examples/Example1-SteadyState/"
@@ -52,6 +52,24 @@ echo "directory contents after G4 test run ..."
 ls -l
 
 
-# TODO: next natural step would be to check if power in this seeded steady-state simulation grows approximately as we expect.
+# stop here
+# exit 0
+
+###
+# analysis of simulation results
+# DEMO: report and check power at end of undulator
+# (reference value for check is coded in TEST_power.py script)
+###
+
+echo
+echo
+./TEST_power.py
+RESULT=$?
+if [[ "$RESULT" -ne "0" ]] ; then
+	echo "test script with non-zero exit code, stopping"
+	exit 1
+fi
+echo
+echo
 
 ###

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,6 +83,16 @@ jobs:
           name: genesis4-${{ matrix.os }}-${{ matrix.mpi }}-system
           path: build/genesis4
 
+
+      - name: prepare Python environment for steady-state test simulation
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install h5py   
+
       - name: Run tests
         run: |
           .github/scripts/run_tests.sh 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build_dpi.yaml
+++ b/.github/workflows/build_dpi.yaml
@@ -69,6 +69,16 @@ jobs:
         shell: bash -eo pipefail -l {0}
         run: .github/scripts/build.sh
 
+
+      - name: prepare Python environment for steady-state test simulation
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install h5py   
+
       - name: Run tests (with DPI)
         run: |
           .github/scripts/run_tests.sh 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -44,6 +44,16 @@ jobs:
           name: genesis4-${{ matrix.os }}-${{ matrix.mpi }}-conda
           path: build/genesis4
 
+
+      - name: prepare Python environment for steady-state test simulation
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: install Python dependencies
+        shell: bash -eo pipefail -l {0}
+        run: |
+          pip install h5py
+
       - name: Run tests
         shell: bash -eo pipefail -l {0}
         run: .github/scripts/run_tests.sh 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"

--- a/examples/Example1-SteadyState/README.md
+++ b/examples/Example1-SteadyState/README.md
@@ -1,4 +1,5 @@
 ## Example 1 : Steady-State Simulation
+**Note:** The steady-state simulation in this directory is part of automatic testing via GitHub Actions. If you change something be sure to check afterwards that script `TEST_power.py` gives "OK" status.
 
 *All files for running the example are found in the subdirectory examples/Example1-SteadyState of the source code distribution*
 

--- a/examples/Example1-SteadyState/TEST_power.py
+++ b/examples/Example1-SteadyState/TEST_power.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Christoph Lechner, Aug 2025
+# Demo for automatic testing: reports FEL power at the end of the simulated beamline
+
+import h5py as h5
+import sys
+
+# power value at end of simulated beamline (using files in commit id 70be16d; Aug 6, 2025)
+Ptest = 0.932785e9
+
+# permissible relative deviation
+maxreldev = 0.3
+
+######
+
+f = h5.File('Example1.out.h5','r')
+P = f['/Field/power'][()]
+f.close()
+
+Pfinal = P[-1]
+Pfinal = Pfinal[0]
+print(f'FEL power at the end of Example1 run: {Pfinal/1e9:.6f}GW')
+
+
+# relative deviations exceeding permissible limit result in exit code signalling error
+reldev = (Pfinal-Ptest)/Ptest
+if abs(reldev)>maxreldev:
+    print(f'relative deviation {reldev} exceeds limit of {maxreldev}')
+    sys.exit(1)
+
+print(f'OK: relative deviation {reldev} within limit {maxreldev}')


### PR DESCRIPTION
This PR adds a check based on simple analysis of the simulation output of the (seeded) steady-state simulation test runs.

The motivation is that if the result of the steady-state test sim is as expected, many key parts of the code should work as expected. OTOH, should the output be off by an order of magnitude, something might be broken.

**Acceptance criterion**
Currently the test acceptance criterion is very relaxed, allowing up to 30-percent relative power deviation from the hard-coded expected value at the end of the beamline. The test acceptance criterion can be adjusted in `TEST_power.py`. If (seeded) steady-state example1 is modified, one should run this script on the command line and make the needed parameter adjustments for the test to succeed.

**Other remarks**
In file `run_tests.sh`, this test based on final power from simulation output can be disabled by uncommenting the `exit 0` line.

This commit is equivalent to commits 61c94ab->bbed from CL's git repo, but with a different base commit (and a small bug fix in file build_dpi.yaml).