### PR TITLE
FIX: H5L_info_t alias is info2 on newer HDF5>=1.12.0

### DIFF
--- a/include/HDF5base.h
+++ b/include/HDF5base.h
@@ -70,7 +70,7 @@ class HDF5Base{
 
 };
 
-extern "C"  herr_t file_info(hid_t loc_id,const char *name, const H5O_info_t *linfo, void *opdata);
+extern "C"  herr_t file_info(hid_t loc_id,const char *name, const H5L_info_t *linfo, void *opdata);
 
 
 #endif

--- a/src/IO/HDF5base.cpp
+++ b/src/IO/HDF5base.cpp
@@ -465,7 +465,7 @@ int HDF5Base::getDatasetSize(hid_t fid, char *name)
 
 herr_t file_info(hid_t loc_id,const char *name, const H5L_info_t *linfo, void *opdata) {
   auto group_names=reinterpret_cast< std::vector<std::string>* >(opdata);
-  H5O_info_t o_info;
+  H5O_info1_t o_info;
   herr_t err = H5Oget_info_by_name1(loc_id, name, &o_info,H5P_DEFAULT);
   if (o_info.type == H5O_TYPE_DATASET) {
     group_names->push_back(name);

--- a/src/IO/HDF5base.cpp
+++ b/src/IO/HDF5base.cpp
@@ -465,7 +465,11 @@ int HDF5Base::getDatasetSize(hid_t fid, char *name)
 
 herr_t file_info(hid_t loc_id,const char *name, const H5L_info_t *linfo, void *opdata) {
   auto group_names=reinterpret_cast< std::vector<std::string>* >(opdata);
+#if H5_VERSION_GE(1,12,0)
   H5O_info1_t o_info;
+#else
+  H5O_info_t o_info;
+#endif
   herr_t err = H5Oget_info_by_name1(loc_id, name, &o_info,H5P_DEFAULT);
   if (o_info.type == H5O_TYPE_DATASET) {
     group_names->push_back(name);


### PR DESCRIPTION
## Background

Current master branch and latest release v4.6.13 is failing to build with recent conda-forge dependencies.
This is due to differences in older vs newer HDF5 version dependencies on the system library build versus the conda-forge build.

### Changes

* Version-based selection of the right `H5L_info*_t` struct
* Correction of the header declaration