### PR TITLE
FIX: non-undulator lat_cy logic error in unrollLattice

### DIFF
--- a/src/Lattice/Lattice.cpp
+++ b/src/Lattice/Lattice.cpp
@@ -385,6 +385,7 @@ void Lattice::unrollLattice(double delz,double gamref, double fielderror, bool o
         lat_ay.push_back(0);
         lat_helical.push_back(0);
         lat_cx.push_back(0);
+        lat_cy.push_back(0);
 
       } else {
         ID *und=(ID *)lat[iele];


### PR DESCRIPTION
This simple logic bug causes the downstream lume-genesis test suite to fail on simple lattices with an out-of-bounds access on `lat_cy`.