### PR TITLE
Fix source_filter being silently ignored in FieldSolverFFT

### DIFF
--- a/include/FieldSolverFFT.h
+++ b/include/FieldSolverFFT.h
@@ -33,7 +33,7 @@ class FieldSolverFFT : public FieldSolver{
     double delz_save {0};
     double ks {1};
     double dk {1};
-    double xc,yc,sig;
+    double xc {1}, yc {1}, sig {1};
     bool hasPlan {false};
     bool doFilter_ {false};
     complex<double> *in, *out;

--- a/src/Core/FieldSolverFFT.cpp
+++ b/src/Core/FieldSolverFFT.cpp
@@ -143,11 +143,13 @@ void FieldSolverFFT::init(double delz,double dgrid, double xks, unsigned int ngr
 }
 
 void FieldSolverFFT::initSourceFilter(double xc_in, double yc_in, double sig_in,bool do_filter) {
-    doFilter_ = do_filter;
-    if (sig <= 0) {  // check for unphysical input
-        doFilter_ = false;
-    }
     xc=xc_in;
     yc=yc_in;
     sig=sig_in;
+    doFilter_ = do_filter;
+    // check for unphysical input. xc and yc are used as divisors when the
+    // sigmoid is tabulated, sig is its width.
+    if ((sig <= 0) || (xc <= 0) || (yc <= 0)) {
+        doFilter_ = false;
+    }
 };


### PR DESCRIPTION
# Fix `source_filter` being silently ignored in `FieldSolverFFT`

**Branch:** `ChristopherMayes:fix/source-filter-noop` → `svenreiche:master`
**Base:** v4.6.14 (`b9e2180`) · **Diff:** 2 files, +7 / −5

## Problem

Setting `source_filter = true` in the `&track` namelist has no effect on the simulation. The sigmoid source filter is never applied, regardless of the values given for `xcut`, `ycut` and `sigmoid`. A user who enables the filter receives an unfiltered result and has no indication that anything was ignored.

## Root cause

`FieldSolverFFT::initSourceFilter` validates its input before storing it:

```cpp
void FieldSolverFFT::initSourceFilter(double xc_in, double yc_in, double sig_in, bool do_filter) {
    doFilter_ = do_filter;
    if (sig <= 0) {  // <-- 'sig' is the member, not sig_in
        doFilter_ = false;
    }
    xc = xc_in;
    yc = yc_in;
    sig = sig_in;
};
```

The guard tests the member variable `sig` rather than the argument `sig_in`. At the point where the test executes, the member still holds whatever value it held before the call. `initSourceFilter` is called exactly once, immediately after construction in `Field::initSolver`, and the members are declared without initialisers:

```cpp
double xc, yc, sig;
```

The test therefore reads an indeterminate value. In practice that value evaluates as less than or equal to zero, so the filter is disabled again on the line immediately after it was enabled.

## Evidence on the released code

The following comparison uses a steady-state ARAMIS run with `ngrid = 256` and `fft_fieldsolver = true`, and contrasts an aggressive filter setting against no filter at all.

| run | `Pmax` [W] | power rel L2 vs unfiltered |
|---|---|---|
| no filter | 1.482346e+09 | — |
| `source_filter=true`, `xcut=ycut=0.02`, `sigmoid=0.01` | 1.482346e+09 | **1.8e-15** |

The two runs are bit-identical, which confirms that the filter never ran.

## Fix

The assignment is moved ahead of the validation. The guard is also extended to cover `xcut` and `ycut`, because both are used as divisors when the sigmoid is tabulated in `init()`, and the members are given the documented defaults so that they are never read while indeterminate.

```cpp
void FieldSolverFFT::initSourceFilter(double xc_in, double yc_in, double sig_in, bool do_filter) {
    xc = xc_in;
    yc = yc_in;
    sig = sig_in;
    doFilter_ = do_filter;
    // check for unphysical input. xc and yc are used as divisors when the
    // sigmoid is tabulated, sig is its width.
    if ((sig <= 0) || (xc <= 0) || (yc <= 0)) {
        doFilter_ = false;
    }
};
```

```cpp
double xc {1}, yc {1}, sig {1};
```

## Validation

The table below reports the relative L2 difference of the power along `z` against an unfiltered run, using the same steady-state ARAMIS case in every row.

| configuration | power rel L2 | `Pmax` [W] | expected behaviour |
|---|---|---|---|
| `source_filter` absent (default) | 1.4e-15 | 1.482346e+09 | unchanged, so there is no regression |
| `xcut=0.8`, `ycut=0.8`, `sigmoid=0.1` | 4.3e-04 | 1.482133e+09 | mild filter, small effect |
| `xcut=0.02`, `ycut=0.02`, `sigmoid=0.01` | 8.1e-01 | 1.250802e+09 | aggressive filter, large effect |
| `xcut=0.8`, `ycut=0.8`, `sigmoid=0` | 0 | 1.482346e+09 | unphysical input, filter correctly disabled |

The default code path is unaffected, the filter now responds to its parameters as documented, and unphysical input still disables it rather than producing a division by zero.

## Reproducing

Add the following block to any deck that uses the FFT field solver:

```
&track
fft_fieldsolver = true
source_filter   = true
xcut            = 0.02
ycut            = 0.02
sigmoid         = 0.01
&end
```

Run the same deck a second time with the four filter lines removed. On v4.6.14 the two outputs are bit-identical. With this patch applied they differ substantially, as the table above shows.

The measurements were taken on macOS running on an Apple M1 Max, using conda-forge clang 19.1.7, FFTW 3, and HDF5 built against MPICH, on a single rank.

## Relationship to the companion pull request

This change is a prerequisite for exercising the three-FFT branch in the companion pull request, *"`FieldSolverFFT`: drop the source-term FFT when the source filter is off"*. On released code that branch is unreachable, so it cannot be tested there. I would suggest reviewing and merging this pull request first.

## Acknowledgement

This investigation and the accompanying patch were prepared with the assistance of Claude Opus 5, running as GitHub Copilot in Visual Studio Code. The model traced the root cause, proposed the fix, and set up the comparison runs. Every measurement quoted above was executed on real hardware, and I have reviewed the diagnosis and the change before submitting them.
