### PR TITLE
FieldSolverFFT: drop the source-term FFT when the source filter is off

### DIFF
--- a/src/Core/FieldSolverFFT.cpp
+++ b/src/Core/FieldSolverFFT.cpp
@@ -63,41 +63,53 @@ void FieldSolverFFT::advance(double delz, Field *field, Beam *beam, Undulator *u
 
 void FieldSolverFFT::FFT(vector<complex<double> > &crfield)
 {
-    // Do the FFT of the field and source term
+    // Transform the field into Fourier space
     for (unsigned long ii = 0; ii < crfield.size(); ii++) {
         in[ii] = crfield[ii];
     }
 #ifdef FFTW
         fftw_execute(p);
 #endif
-    for (unsigned long ii = 0; ii < crfield.size(); ii++) {
-        uf[ii] = out[ii];
-        in[ii] = crsource[ii];
-    }
+
+    if (doFilter_) {
+        // The source term is filtered in Fourier space, so it needs its own
+        // forward transform.
+        for (unsigned long ii = 0; ii < crfield.size(); ii++) {
+            uf[ii] = out[ii];
+            in[ii] = crsource[ii];
+        }
 #ifdef FFTW
         fftw_execute(p);
 #endif
-
-    for (unsigned long ii = 0; ii < crfield.size(); ii++) {
-        sf[ii] = out[ii];
-    }
-    // filter source term
-    if (doFilter_) {
         for (unsigned long ii = 0; ii < crfield.size(); ii++) {
-            sf[ii]*=sigmoid_[ii];
+            sf[ii] = out[ii] * sigmoid_[ii];
         }
-    }
-
-    // do the actual propagation
-    for (unsigned long ii = 0; ii < crfield.size(); ii++) {
-        in[ii]=uf[ii]*exp(K2[ii]*delz_save) + 2.*sf[ii]; // - complex<double>(0,1.) *sf[ii];
+        // do the actual propagation
+        for (unsigned long ii = 0; ii < crfield.size(); ii++) {
+            in[ii] = uf[ii] * exp(K2[ii] * delz_save) + 2. * sf[ii];
+        }
+    } else {
+        // Without the filter the source term is not modified in Fourier space.
+        // The transform is linear, so IFFT(FFT(crsource))/ngrid^2 == crsource
+        // and the source can simply be added in real space after the back
+        // transform. This saves one of the three 2D FFTs per slice and step.
+        for (unsigned long ii = 0; ii < crfield.size(); ii++) {
+            in[ii] = out[ii] * exp(K2[ii] * delz_save);
+        }
     }
 #ifdef FFTW
         fftw_execute(ip);
 #endif
+
     double norm = 1./static_cast<double>(ngrid*ngrid);
-    for (unsigned long ii = 0; ii < crfield.size(); ii++) {
-        crfield[ii]=out[ii]*norm;
+    if (doFilter_) {
+        for (unsigned long ii = 0; ii < crfield.size(); ii++) {
+            crfield[ii] = out[ii] * norm;
+        }
+    } else {
+        for (unsigned long ii = 0; ii < crfield.size(); ii++) {
+            crfield[ii] = out[ii] * norm + 2. * crsource[ii];
+        }
     }
 }
 


### PR DESCRIPTION
# `FieldSolverFFT`: drop the source-term FFT when the source filter is off

**Branch:** `ChristopherMayes:perf/fft-two-pass` → `svenreiche:master`
**Base:** v4.6.14 (`b9e2180`) · **Diff:** 1 file, +31 / −19

## Summary

The FFT field solver performs three two-dimensional FFTs for every slice and every integration step. One of those transforms is unnecessary whenever the sigmoid source filter is switched off, which is the default configuration. Removing it is an exact algebraic identity rather than an approximation, so the results are unchanged to round-off.

The measured improvement is a factor of 1.11 to 1.14 in wall clock time on realistic cases, with agreement at the bit level.

## The redundancy

`FieldSolverFFT::FFT` currently performs the following three steps:

1. a forward FFT of the field,
2. a forward FFT of the source term,
3. a back FFT of `field * exp(K2 * delz) + 2 * source`.

The source term is only manipulated in Fourier space when the filter is enabled, because that is the only place where `sigmoid_` is applied. When the filter is off, the transform pair acts as a linear identity on the source term:

```
IFFT( FFT(crsource) ) / ngrid^2  ==  crsource
```

The source can therefore be added in real space after the back transform, and the second step disappears entirely:

```
crfield  =  IFFT( FFT(crfield) * exp(K2*delz) ) / ngrid^2  +  2 * crsource
```

## The change

`FFT()` now branches on `doFilter_`. The filtered branch is byte-for-byte the original algorithm and still performs three FFTs, so behaviour with the filter enabled is unchanged. The unfiltered branch performs two.

There are no changes to any public interface, no new input options, and no new state.

## Correctness

The new code was verified against the previous implementation on the ARAMIS benchmark lattice.

The first case is steady-state lasing over 57 m with `ngrid = 256`, two harmonics, and `fft_fieldsolver = true`.

| quantity | result |
|---|---|
| gain length $L_g$ | identical to all printed digits |
| $P_{\rm sat}$ | relative difference 3.2e-16 |
| power along $z$ | relative L2 6.0e-16 |
| bunching along $z$ | relative L2 **0** |
| beam energy along $z$ | relative L2 4.8e-18 |

The second case is time-dependent SASE with 504 slices, `zstop = 20`, and shot noise enabled.

| quantity | result |
|---|---|
| power | relative L2 8.9e-16 |
| bunching | relative L2 **0** |
| temporal profile at final $z$ | correlation 1.0000000000 |

All of these differences are at round-off, which is what an exact identity should produce.

The filtered branch cannot be exercised on released code, because `source_filter` is silently ignored there. That defect is addressed in the companion pull request #272, *"Fix `source_filter` being silently ignored in `FieldSolverFFT`"*. With that fix applied, the two-FFT and three-FFT paths agree at round-off:

| filter setting | power relative L2 |
|---|---|
| `xcut=0.8`, `ycut=0.8`, `sigmoid=0.1` | 1.5e-15 |
| `xcut=0.02`, `ycut=0.02`, `sigmoid=0.01` | 6.9e-16 |

The two branches merge cleanly, because they touch different functions within the same file.

## Performance

The following timings were taken on an Apple M1 Max using conda-forge clang 19.1.7 and FFTW 3, on a single rank, with `fft_fieldsolver = true`.

| case | before | after | speedup |
|---|---|---|---|
| steady state, 57 m, two harmonics | 7.58 s | 6.66 s | **1.14×** |
| time-dependent SASE, 504 slices, `zstop=20`, one harmonic | 191.0 s | 172.0 s | **1.11×** |

The isolated field solve performs a third less FFT work. The end-to-end gain is smaller than that because it is diluted by the source deposition loop and the particle push, neither of which is touched by this change.

An isolated single-precision FFT micro-benchmark at `ngrid = 256` improves from 1112 µs to 755 µs, a factor of 1.47 for the transform work alone. That figure is consistent with the end-to-end numbers once the deposition and push are taken into account.

## Unrelated observation

`ngrid = 255`, which factorises as 3 × 5 × 17, is a poor length for an FFT. On the same machine, a 64-slice benchmark with `zstop = 4` takes 59.7 s at `ngrid = 255` against 38.3 s at `ngrid = 256` when using the FFT solver. For comparison, the ADI solver takes 41.6 s and 36.4 s respectively on the same two grids. This may be worth a note in the manual, but it is not part of this pull request.

## Acknowledgement

This change and its validation were prepared with the assistance of Claude Opus 5, running as GitHub Copilot in Visual Studio Code. The model identified the redundant transform, implemented the branch, and set up the comparison and timing runs. Every measurement quoted above was executed on real hardware, and I have reviewed the reasoning and the change before submitting them.
