### PR TITLE
Skip the user diagnostic's per-particle work when its output is disabled

### DIFF
--- a/src/Core/DiagnosticUser.cpp
+++ b/src/Core/DiagnosticUser.cpp
@@ -52,50 +52,60 @@ void DiagBeamUser::getValues(Beam *beam, std::map<std::string,std::vector<double
     double g_norm = 0;   // global variable for normalizing the other global variables (here the current)
     double g_loss = 0;   // global variable for beam loss
 
+    // Resolve the output record once, before the slice loop. Everything below
+    // that touches individual particles exists only to fill "modulation", and
+    // it costs a sine and a cosine per particle per slice per integration step.
+    // With the template disabled that work is thrown away, so check first
+    // whether the output was actually requested. A user adding a diagnostic
+    // here should guard their own per-particle work the same way.
+    std::vector<double> *v_modulation = nullptr;
+    auto it_mod = val.find("modulation");
+    if (it_mod != val.end()) { v_modulation = &it_mod->second; }
+
     // loop over the slices in the electron bunch
     for (auto const &slice: beam->beam) {
-        double gamavg=0.;
-        complex<double> emod = 0; // parameter for the energy modulation
-        double norm = 1.;
-
-        if (!slice.empty()) {
-            norm = 1./static_cast<double>(slice.size()); // normalize with the number of particles per slice
-        }
-
-        // compute average gamma value (lechner, 2022-Dec)
-        // Needed for correct computation of Emod by first
-        // subtracting <gamma>.
-        // My key parameters: I=5kA, one4one=true, 16.5GeV, emod=10, 17keV
-        for (auto const &par: slice) {
-            gamavg+=par.gamma;
-        }
-        gamavg *= norm;
-
-        // loop over the particle in each slice
-        for (auto const &par: slice) {
-            emod += (par.gamma-gamavg) * complex<double>(cos(par.theta),sin(par.theta));
-        }
-        emod *= norm;
-
-        // Compute modulation *amplitude*
-        // Factor of 2: cos(phi) = 1/2*(exp(i*phi)+exp(-i*phi))
-        double emod_ampl = 2 * abs(emod);
-
-
-        // gather info for the global variables
-        g_norm += beam->current[is];
-        g_loss += beam->current[is] * beam->eloss[is];
-
-
         // saving the calculated values into the records defined with getTags.
         // (1) Compute index into data array.
         //     For 'once' parameters it would be just idx=is
         //     For 'global' parameters it would just iz
         int idx = iz*ns + is;         // index for saving the data in the individual vectors of 'val'
 
-        // (2) Store value
-        // It is good practice to check whether a given tag exists, since they can vary with filter flags, such as for global parameters
-        if (val.find("modulation") != val.end()) { val["modulation"][idx] = emod_ampl; }
+        if (v_modulation != nullptr) {
+            double gamavg=0.;
+            complex<double> emod = 0; // parameter for the energy modulation
+            double norm = 1.;
+
+            if (!slice.empty()) {
+                norm = 1./static_cast<double>(slice.size()); // normalize with the number of particles per slice
+            }
+
+            // compute average gamma value (lechner, 2022-Dec)
+            // Needed for correct computation of Emod by first
+            // subtracting <gamma>.
+            // My key parameters: I=5kA, one4one=true, 16.5GeV, emod=10, 17keV
+            for (auto const &par: slice) {
+                gamavg+=par.gamma;
+            }
+            gamavg *= norm;
+
+            // loop over the particle in each slice
+            for (auto const &par: slice) {
+                emod += (par.gamma-gamavg) * complex<double>(cos(par.theta),sin(par.theta));
+            }
+            emod *= norm;
+
+            // Compute modulation *amplitude*
+            // Factor of 2: cos(phi) = 1/2*(exp(i*phi)+exp(-i*phi))
+            double emod_ampl = 2 * abs(emod);
+
+            // (2) Store value
+            (*v_modulation)[idx] = emod_ampl;
+        }
+
+        // gather info for the global variables
+        g_norm += beam->current[is];
+        g_loss += beam->current[is] * beam->eloss[is];
+
         is++; // and increment slice counter (FIXME: consider replacing the outer loop by traditional 'for' loop)
     }
 


### PR DESCRIPTION
### Summary

`DiagBeamUser::getValues` in `src/Core/DiagnosticUser.cpp` computes a beam modulation amplitude that requires a `sin` and a `cos` evaluation for every particle, in every slice, on every integration step.

The `modulation` output is registered only when `filter["template"]` is true, and the file ships with that flag set to false. On a stock build, therefore, this trigonometry is evaluated for every particle on every step and the result is then discarded.

The guard against this already existed, but it was placed at the end of the loop body, after the work had been performed:

```cpp
// ... full per-particle loop computing emod_ampl ...
if (val.find("modulation") != val.end()) { val["modulation"][idx] = emod_ampl; }
```

This pull request resolves the output record once, before the slice loop begins, and skips the accumulation entirely when the output has not been requested. When the template is enabled, the same code executes and produces the same results.

Because this file serves as the template that users copy when adding their own diagnostics, I have also added a comment explaining that per-particle work should be placed behind the same check.

### Impact

The measurements below were taken on an ARAMIS SASE deck with 500 slices, using a sampling profile of a single rank:

| frame | share of main thread |
| --- | ---: |
| `Diagnostic::calc` | 17.9% |
| ├ `DiagField::getValues` | 9.1% |
| ├ `DiagBeam::getValues` | 3.7% |
| └ `DiagBeamUser::getValues` | **2.0%** |

After the change, `DiagBeamUser::getValues` no longer appears in the profile at all.

A saving of 2% is modest on a CPU-only run, where the field solver dominates the runtime. The cost becomes considerably more significant as the field solve becomes cheaper. On a build with an accelerated solver, this single function accounted for approximately three quarters of the per-step time, and removing it reduced a benchmark from 7.33 s to 1.57 s.

### Correctness

I performed two checks against unmodified `master`, both using 8 ranks.

1. With the default build, in which the template is disabled, the `/Beam` group is bit-identical:

   ```
   h5diff ref.out.h5 new.out.h5 /Beam /Beam
   0 differences found
   ```

2. With `filter["template"] = true`, the `/Beam/modulation` dataset agrees to better than `1e-10` in relative terms. An exact comparison reports last-bit differences of approximately 4e-16 in absolute terms, against values of order 1e-2. To establish whether these differences were meaningful, I ran the unmodified binary against itself as a control:

   | comparison | exact differences | at `-p 1e-10` |
   | --- | ---: | ---: |
   | control: unmodified binary, run twice | 912 | 0 |
   | unmodified binary vs. this pull request | 645 | 0 |

   The modified code therefore differs from the reference by less than the reference differs from itself. This run-to-run variation originates in `FFTW_MEASURE`, which may select different plans between runs.

### Scope

This pull request modifies a single file, `src/Core/DiagnosticUser.cpp`, with 45 lines added and 35 removed. It introduces no changes to the API, the output format, or the input file syntax.

I have marked it as a draft. If you would prefer the guard to be expressed differently, I would be glad to revise it.

### Acknowledgement

This change and its validation were prepared with the assistance of Claude Opus 5, running as GitHub Copilot in Visual Studio Code. The model located the misplaced guard while profiling an unrelated piece of work, implemented the fix, and set up the profiling and equivalence runs. Every measurement quoted above was executed on real hardware, and I have reviewed the reasoning and the change before submitting them.
