### PR TITLE
Fix an uncaught exception when `&lattice` sets a seed

### DIFF
--- a/src/Lattice/AlterLattice.cpp
+++ b/src/Lattice/AlterLattice.cpp
@@ -29,6 +29,7 @@ void AlterLattice::usage(){
   cout << " bool add = true" << endl;
   cout << " bool fielderror = 0" << endl;
   cout << " bool orbiterror = false" << endl;
+  cout << " int seed = 1234567" << endl;
   cout << "&end" << endl << endl;
   }
 
@@ -62,7 +63,7 @@ bool AlterLattice::init(int inrank, int insize, map<string,string> *arg, Lattice
   if (arg->find("add")!=end)     {add  = atob(arg->at("add"));    arg->erase(arg->find("add"));}
   if (arg->find("orbiterror")!=end)     {orbiterror  = atob(arg->at("orbiterror"));    arg->erase(arg->find("orbiterror"));}
   if (arg->find("fielderror")!=end)  {fielderror= atof(arg->at("fielderror").c_str());  arg->erase(arg->find("fielderror"));}
-  if (arg->find("seed")!=end){ iseed= atoi(arg->at("iseed").c_str());  arg->erase(arg->find("iseed"));}
+  if (arg->find("seed")!=end){ iseed= atoi(arg->at("seed").c_str());  arg->erase(arg->find("seed"));}
 
   if (!arg->empty()){
     if (rank==0){ cout << "*** Error: Unknown elements in &lattice" << endl; this->usage();}


### PR DESCRIPTION
`AlterLattice::init` tests for the key `seed` but then reads the key `iseed`, which is never present, so `std::map::at` throws. A deck that seeds the undulator errors aborts during lattice parsing with

```
libc++abi: terminating due to uncaught exception of type std::out_of_range: map::at: key not found
```

and no indication of which namelist was responsible.

```cpp
if (arg->find("seed")!=end){ iseed= atoi(arg->at("iseed").c_str());  arg->erase(arg->find("iseed"));}
```

Neither spelling works at present. Writing `seed`, which is what `manual/MAIN_INPUT.md` documents for `&lattice`, matches the `find` and then throws in the `at`. Writing `iseed` does not match the `find`, so it survives to the emptiness check and is reported as an unknown element. Undulator field and orbit errors are therefore stuck on the fixed default of 1234567, with no way to vary the error realisation between runs.

The value is genuinely used rather than vestigial: `Lattice::generate` passes `alt->getSeed()` into `unrollLattice` alongside `getFieldError()` and `getOrbitError()`.

This pull request also lists `seed` in `AlterLattice::usage`, which never mentioned it, so the help printed after a mistyped keyword did not name the one the user wanted.

## Verification

Using the shipped `benchmark/Benchmark1-SASE` deck with `fielderror = 0.01` and `orbiterror = true` added to `&lattice`. Before the change the run aborts as above. After it:

| seed | rms of `Lattice/aw` about its mean |
|---|---|
| 84621 | 9.1e-03 |
| 11111 | 9.9e-03 |

Both are consistent with the requested `fielderror = 0.01`, and the two realisations differ from each other by 1.3e-02, confirming that the seed now selects the realisation. `Beam/xposition` differs accordingly between the two runs.

The change is two lines in one file. I have marked it as a draft, and would be glad to revise it if you would prefer the keyword to be spelled `iseed` in the input file instead, which would be the other way of reconciling the code with itself.

## Acknowledgement

This fix and its validation were prepared with the assistance of Claude Opus 5, running as GitHub Copilot in Visual Studio Code. The model encountered the crash while building a validation matrix for an unrelated piece of work, traced it to the mismatched key, and set up the runs that confirm the seed now reaches the error generator. Every measurement quoted above was executed on real hardware, and I have reviewed the diagnosis and the change before submitting them.
