### PR TITLE
Report the wall clock time rather than the processor time at the end of a run

### DIFF
--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <cstring>
 #include <ctime>
+#include <chrono>
 
 
 #include <fenv.h>
@@ -87,8 +88,14 @@ int genmain (string inputfile, map<string,string> &comarg, bool split) {
     }
 
     time_t timer;
-    clock_t clocknow;
-    clock_t clockstart = clock();
+    // Wall clock, as the line printed at the end says. It used to be clock(),
+    // which is processor time: equal to the wall clock for a run that computes
+    // on the host without waiting, but not for one that waits on a GPU, on a
+    // file system or on another rank, where it under-reports, sometimes by a
+    // factor of four.
+    std::chrono::steady_clock::time_point clocknow;
+    const std::chrono::steady_clock::time_point clockstart =
+        std::chrono::steady_clock::now();
     //	evt0 = double(clockstart);
     //	event.push_back("start");
     //	evtime.push_back(0);
@@ -527,7 +534,7 @@ int genmain (string inputfile, map<string,string> &comarg, bool split) {
 	/* take time stamp (I/O for generating semaphore file could skew result if file system is busy) */ 
 	//	event.push_back("end");
 	//	evtime.push_back(double(clocknow-clockstart));
-	clocknow=clock();
+	clocknow=std::chrono::steady_clock::now();
 
 
         /* NOW, generate the semaphore file */
@@ -551,7 +558,7 @@ int genmain (string inputfile, map<string,string> &comarg, bool split) {
 
 
  	if (rank==0) {
-	  double elapsed_Sec=double(clocknow-clockstart)/CLOCKS_PER_SEC;
+	  double elapsed_Sec=std::chrono::duration<double>(clocknow-clockstart).count();
 
       time(&timer);
       cout << endl<< "Program is terminating..." << endl;


### PR DESCRIPTION
The line printed at the end of every run reports processor time rather than elapsed time, although it is labelled as the wall clock:

```cpp
clock_t clockstart = clock();
...
clocknow=clock();
double elapsed_Sec=double(clocknow-clockstart)/CLOCKS_PER_SEC;
cout << "Total Wall Clock Time: " << elapsed_Sec << " seconds" << endl;
```

For a run that computes on the host from beginning to end, the two quantities are the same number, which is why this has not caused trouble so far. They part company whenever the process waits rather than computes: while writing to the file system, while blocked on another rank, or while waiting on a device. The figure printed is also rank zero's processor time alone, so it describes one process rather than the run.

This pull request measures `std::chrono::steady_clock` instead, which is what the label already claims to be. The change is three lines in `GenMain.cpp`, plus the `<chrono>` include.

## Verification

The measurements below use 500 slices of the ARAMIS SASE example at `ngrid = 64` with `field_dump_step = 4`, so that the run spends a visible part of its time writing field dumps rather than computing. The external wall clock is taken around the whole `mpirun` invocation.

| ranks | external wall clock | reported before | reported after |
|---:|---:|---:|---:|
| 1 | 59.19 s | 58.49 s | 58.55 s |
| 8 | 8.99 s | 8.34 s | 8.92 s |

The under-report is modest in this configuration, seven per cent at eight ranks, because the only waiting is on the file writes. It grows with anything the run waits on for longer. I noticed the discrepancy while timing an experimental GPU backend, where a run that waits on a device reported 1.2 seconds against 5.2 seconds of elapsed time, since waiting on a device costs no processor time whatsoever. The error can also run in the other direction: on a build that used threads, `clock()` sums the processor time of all of them and would report more than the elapsed time rather than less.

The practical consequence is that anyone comparing configurations by reading this line, whether that is more ranks against fewer or one file system against another, is comparing numbers that are only approximately what they appear to be.

I have marked this as a draft. The change alters a number that users see, in that reported times will now be slightly larger than before and equal to the true elapsed time, and I would be glad to adjust it if you would rather keep the existing quantity and change the label instead.

## Acknowledgement

This change and its verification were prepared with the assistance of Claude Opus 5, running as Claude Code in Visual Studio Code. The model found the discrepancy while measuring the performance of an unrelated piece of work, identified `clock()` as the cause, and set up the runs quoted above. Every measurement was executed on real hardware, and I have reviewed the diagnosis and the change before submitting them.
