### PR TITLE
Take the on-axis field diagnostic from the axis when ngrid is even

### DIFF
--- a/src/Core/Diagnostic.cpp
+++ b/src/Core/Diagnostic.cpp
@@ -847,7 +847,12 @@ void DiagField::getValues(Field *field,std::map<std::string,std::vector<double> 
 #endif
 
 
-        int i=(ngrid*ngrid-1)/2;
+        // Cell on the axis. (ngrid*ngrid-1)/2 is that cell only for an odd
+        // ngrid, which is the traditional Genesis convention; for an even one
+        // it lands on the last column of the row below the middle, at the edge
+        // of the grid, where the field is orders of magnitude smaller than on
+        // axis. This form is identical for odd ngrid and correct for even.
+        int i=(ngrid/2)*ngrid+(ngrid/2);
         loc=slice.at(i);
         double inten=loc.real()*loc.real()+loc.imag()*loc.imag();
         double intenphi=atan2(loc.imag(),loc.real());

--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -432,7 +432,9 @@ void Field::diagnostics(bool output)
     if (bfarfield > 0){
       bphiff=atan2(ff.imag(),ff.real());
     }
-    int i=(ngrid*ngrid-1)/2;
+    // Cell on the axis; see the same expression in DiagField::getValues. The
+    // older (ngrid*ngrid-1)/2 is the axis only for an odd ngrid.
+    int i=(ngrid/2)*ngrid+(ngrid/2);
     loc=field.at(islice).at(i);
     bintensity=loc.real()*loc.real()+loc.imag()*loc.imag();
     if (bintensity > 0) {


### PR DESCRIPTION
`DiagField::getValues` reports the field in the cell at the centre of the transverse grid as `intensity-nearfield` and `phase-nearfield`, and selects that cell as follows:

```cpp
int i=(ngrid*ngrid-1)/2;
loc=slice.at(i);
```

For an odd `ngrid`, which is the traditional Genesis convention precisely because it puts a grid point on axis, this is exactly the centre cell. For an even `ngrid` it is not. With integer division the expression becomes `(ngrid/2 - 1)*ngrid + (ngrid - 1)`, which is the last column of the row below the middle, that is to say a cell on the edge of the box. At `ngrid = 256` the index is 32767, which is row 127, column 255.

A deck with an even `ngrid` therefore reports a near-field intensity and a near-field phase taken from the boundary of the grid, where the field is orders of magnitude weaker than on axis. No other field diagnostic is affected, because every other one is either a sum or an intensity-weighted moment over the whole grid.

`(ngrid/2)*ngrid + ngrid/2` is the same index for an odd `ngrid`, so no result from a deck that follows the usual convention changes, and it is the centre cell for an even one. `Field::diagnostics` keeps its own copy of these two quantities and selects the cell the same way, so it is corrected alongside.

## Verification

A steady-state ARAMIS run at `ngrid = 256` on a CPU-only build, with no other change. Since the mode is close to Gaussian, the on-axis intensity should be near `P / (2 pi sigma^2)`, which can be formed from `Field/power` and `Field/xsize` in the same output file. Comparing that estimate with the reported `intensity-nearfield`, at the peak of each along the undulator:

| | reported `intensity-nearfield` | implied on axis | ratio |
|---|---:|---:|---:|
| before | 3.00e+15 W/m^2 | 1.16e+18 W/m^2 | 0.0026 |
| after | 1.54e+18 W/m^2 | 1.16e+18 W/m^2 | 1.32 |

Before the change the reported value is a factor of four hundred too small, which is the field at the edge of the box rather than on axis. After it, the ratio is of order unity, as it should be for a mode that is close to but not exactly Gaussian.

## How this came up

I have been building an experimental GPU field solver, whose transform accepts only powers of two, so all of its decks use an even `ngrid`. An end-to-end comparison against the CPU path disagreed by four per cent on `intensity-nearfield` while agreeing to one part in a thousand on `Field/power` and on the far-field quantities. A disagreement confined to a single quantity, and that quantity the value of one cell, pointed at the index rather than at the physics. Nothing about the diagnosis depends on the accelerator: the index is the CPU path's own, and the verification above is a CPU-only build.

Even grids are worth supporting regardless: an odd `ngrid` such as 255 factors as 3 x 5 x 17, which is a poor length for an FFT, so a deck using the FFT field solver has a good reason to prefer a power of two.

I have marked this as a draft. The change alters `intensity-nearfield` and `phase-nearfield` for anyone who has been running an even `ngrid`, which is the point of it, and I would be glad to revise it if you would prefer the on-axis value to be interpolated between the four central cells instead of taken from one of them, which would be the other reasonable reading of "on axis" for an even grid.

## Acknowledgement

This change and its verification were prepared with the assistance of Claude Opus 5, running as Claude Code in Visual Studio Code. The model traced the discrepancy from a validation sweep to the cell index, confirmed that it reproduces without any accelerator involved, and set up the comparison quoted above. Every measurement was executed on real hardware, and I have reviewed the diagnosis and the change before submitting them.
