### PR TITLE
Take the electron rest energy from one constant, and from CODATA

### DIFF
--- a/include/Collective.h
+++ b/include/Collective.h
@@ -14,6 +14,7 @@ class Undulator;
 
 extern bool MPISingle; 
 extern const double ce;   
+extern const double eev;
 
 using namespace std;
 

--- a/include/EFieldSolver.h
+++ b/include/EFieldSolver.h
@@ -50,7 +50,7 @@ private:
 };
 
 inline double EFieldSolver::getSCField(int islice) {
-    return efield[islice]*511000;  // convert from Lorent mass unit to eV /m
+    return efield[islice]*eev;  // convert from Lorent mass unit to eV /m
 }
 
 inline bool EFieldSolver::hasShortRange() const{

--- a/src/Core/BeamSolver.cpp
+++ b/src/Core/BeamSolver.cpp
@@ -47,7 +47,7 @@ void BeamSolver::advance(double delz, Beam *beam, vector< Field *> *field, Undul
     auto gammaz2 = und->getGammaRef()*und->getGammaRef()/(1+aw*aw);
     for (int is = 0; is < beam->beam.size(); is++) {
         // accumulate space charge field
-        double eloss = -beam->longESC[is] / 511000; // convert eV to units of electron rest mass
+        double eloss = -beam->longESC[is] / eev; // convert eV to units of electron rest mass
         efield.shortRange(&beam->beam.at(is), beam->current.at(is), gammaz2, is);
         for (int ip = 0; ip < beam->beam.at(is).size(); ip++) {
             gamma = beam->beam.at(is).at(ip).gamma;

--- a/src/Core/Collective.cpp
+++ b/src/Core/Collective.cpp
@@ -120,7 +120,7 @@ void Collective::apply(Beam *beam, Undulator *und, double delz)
 
   for (int ic = 0; ic <beam->current.size(); ic++){
     beam->eloss[ic]=wakeext.at(ic)+wakeint.at(ic);
-    double dg=beam->eloss[ic]*delz/511000;    // actual beam loss per integration step
+    double dg=beam->eloss[ic]*delz/eev;    // actual beam loss per integration step
     unsigned long npart=beam->beam.at(ic).size();
     for (unsigned long ip=0; ip<npart; ip++){
       beam->beam.at(ic).at(ip).gamma+=dg;

--- a/src/Main/GenMain.cpp
+++ b/src/Main/GenMain.cpp
@@ -60,7 +60,10 @@
 using namespace std;
 
 const double vacimp = 376.73;
-const double eev    = 510999.06; 
+// Electron rest energy in eV. CODATA 2022: 0.510 998 950 69 MeV, with an
+// uncertainty in the last two digits.
+// https://physics.nist.gov/cgi-bin/cuu/Value?mec2mev
+const double eev    = 510998.95069;
 const double ce     = 4.8032045e-11;
 
 // info for the meta group in the hdf5 output file


### PR DESCRIPTION
The electron rest energy is written down twice in Genesis, in two different ways and with two different values. It exists as the global `eev`, defined in `GenMain.cpp` as 510999.06 eV and used by the field solvers, the loading and the diagnostics, and it is also open-coded as the literal `511000` in three places:

```cpp
// BeamSolver.cpp, long-range space charge
double eloss = -beam->longESC[is] / 511000; // convert eV to units of electron rest mass

// Collective.cpp, wakefield loss per integration step
double dg=beam->eloss[ic]*delz/511000;

// EFieldSolver.h, space-charge field accessor
return efield[islice]*511000;  // convert from Lorent mass unit to eV /m
```

The consequence is not just untidiness. The collective terms are converted between eV and units of the electron rest mass against a mass that differs by 1.8e-06 from the one the field solver and the diagnostics use, so a run with a wakefield or with space charge is internally inconsistent at the part-per-million level. This pull request makes all three use `eev`.

While there, `eev` is updated from 510999.06 to 510998.95069 eV, the CODATA 2022 value of 0.510 998 950 69 MeV, with the NIST reference in the comment. That is a smaller correction than the inconsistency being removed: the literal was 1.8e-06 away from the constant, and the constant is 2.1e-07 away from CODATA.

`Collective.h` gains an `extern const double eev;` next to the declaration it already has for `ce`. Nothing else changes.

## What it does to results

Because `eev` enters the source term of the field solve, the amplitude of a loaded field and the conversion of intensity to W/m², every result moves slightly. Measured on the shipped `benchmark/Benchmark1-SASE` deck, unmodified, comparing a build of current master against a build of this branch, as the largest relative difference over the run:

| dataset | difference |
|---|---:|
| `Beam/bunching3` | 1.8e-05 |
| `Beam/bunching2` | 3.1e-06 |
| `Field/intensity-nearfield` | 2.2e-06 |
| `Field/intensity-farfield` | 9.6e-07 |
| `Field/power` | 6.6e-07 |
| `Field/Global/energy` | 6.6e-07 |

The centroids are unaffected in any meaningful sense: `Field/xposition` moves by 1.2e-11 m against its own scale of 1.0e-06 m.

Two figures deserve to be called out rather than buried. `Beam/bunchingphase3`, the phase of the third-harmonic bunching, moves by 2.0e-02 radians, and `Beam/bunching3` by 1.8e-05, both of which are larger than the change in the constant because this deck runs the full undulator into saturation and the third harmonic is the most sensitive thing in the output file. Anyone diffing old output against new will see these, and they are the honest consequence of changing a physical constant rather than a sign that something is wrong.

The three sites that carried the literal are not exercised by any deck in `benchmark/` or `examples/`, since none of them defines a `&wake` or an `&efield` block, so their effect is quoted above as arithmetic rather than as a measurement.

## A note on naming

`eev` is not an obvious name for the electron rest energy, and something like `mec2` would read better. I have deliberately not renamed it: it appears 33 times across 25 files, and a rename would put a conflict into every one of them for no functional gain. If you would like the rename, it is a separate and purely mechanical change and I am happy to prepare it.

I have marked this as a draft, since it moves numbers that users may be comparing against. If you would rather keep the current value of `eev` and take only the unification of the three literals, that is a two-line change to this branch and the results then move by 1.8e-06 in the collective terms alone, with everything else bit-identical.

## Acknowledgement

This change and its verification were prepared with the assistance of Claude Opus 5, running as Claude Code in Visual Studio Code. The model found the mismatch between the literal and the constant while porting the collective terms to an experimental GPU backend, and set up the before-and-after runs quoted above. Every measurement was executed on real hardware, and I have reviewed the diagnosis and the change before submitting them.
