### PR TITLE
Fix an out-of-bounds read that aborts any steady-state run with a `&wake` namelist

### DIFF
--- a/src/Main/Wake.cpp
+++ b/src/Main/Wake.cpp
@@ -86,7 +86,11 @@ bool Wake::init(int rank, int size, map<string,string> *arg,  Time *time, Setup 
   int nsNode=time->getNodeNSlice();
   
   ns=ns*time->getSampleRate();
-  ds=(s[1]-s[0])/time->getSampleRate();
+  // getPosition returns a single slice for a steady-state run, so s[1] is one
+  // past the end of the vector. A lone slice is one reference length long,
+  // which is what getPosition would have spaced the second one by.
+  ds = (s.size() > 1) ? (s[1]-s[0])/time->getSampleRate()
+                      : setup->getReferenceLength();
 
   wakeres = new double [ns];
   wakegeo = new double [ns];


### PR DESCRIPTION
`Wake::init` reads the longitudinal grid spacing as `s[1]-s[0]`, but `Time::getPosition` returns a single slice for a steady-state run, so `s[1]` is one element past the end of the vector. Any deck that contains a `&wake` namelist and no `&time` namelist therefore builds its wakefield from whatever happens to follow that vector in the heap.

```cpp
vector<double> s;
ns=time->getPosition(&s);          // returns 1 for a steady-state run
...
ds=(s[1]-s[0])/time->getSampleRate();
```

What this does depends entirely on the allocator. Where the following word holds a plausible number the run completes and the wake is quietly meaningless; where it holds a copy of `s[0]`, which is what glibc returns on the machine used here, `ds` becomes zero and the slice index formed in `Collective::update` is `floor(0/0)`. That is a NaN, the subsequent cast to `int` is undefined and produces `INT_MIN`, and the run aborts inside the interpolation of the current profile with a message that names neither the namelist responsible nor the fact that the run was steady state.

```
terminate called after throwing an instance of 'std::out_of_range'
  what():  vector::_M_range_check: __n (which is 2147483648) >= this->size() (which is 2)
```

The fix is to take the separation from something that exists. A steady-state run models a single slice one reference length long, which is precisely the spacing `getPosition` would have used had there been a second slice to space, so that is the value the separation takes when there is only one. For every deck with more than one slice the expression is unchanged, and the pull request is five lines in one file.

I should say why this seems worth fixing rather than refusing, because declaring `&wake` invalid in a steady-state run would also be a defensible response. The reason is the external `loss` term: a `&wake` namelist containing nothing but `loss` is a user-specified constant energy loss per metre, it requires no current profile and no convolution over slices, and it is exactly as meaningful in a steady-state run as in a time-dependent one. That configuration aborts today as well. It would be a shame to lose it in order to avoid the degenerate convolution, particularly as the degenerate convolution turns out to give a sensible answer.

## Verification

All of the following uses the shipped `examples/Example1-SteadyState/Example1.in`, unmodified apart from the namelist named in each case and `zstop = 1` to keep the runs short, built without the GPU backend and run on Linux with glibc.

Adding a stock copper resistive-wall block to that deck aborts as above before the change. After the change the run completes and reports a loss of `-2.875` eV/m, and the beam loses `5.80e-06` in gamma over one metre against the `5.63e-06` that the reported loss predicts, the remainder being the FEL interaction that is present in the reference run as well. This is a small number because a steady-state run models one optical wavelength of an infinitely long uniform bunch, so what survives the convolution is the self-loading term alone; that is the correct answer for the model rather than an artefact of the change, and it is worth knowing that a steady-state wake is not a substitute for a time-dependent one.

The external loss case is the clearer demonstration, since it exercises none of the convolution machinery. A deck whose entire `&wake` namelist is `loss = 1000` aborts before the change; after it, `Beam/wakefield` reports exactly the `1000` eV/m requested and the energy change over one metre matches it to within the FEL interaction.

| deck, steady state | before | after |
|---|---|---|
| `&wake` with `material = CU`, `radius = 2.5e-3` | aborts | `Beam/wakefield` = `-2.875` eV/m |
| `&wake` with `loss = 1000` and nothing else | aborts | `Beam/wakefield` = `1000` eV/m |

No time-dependent result moves. The same deck with `slen = 4.0e-7` added, which is 4000 slices, was run against binaries built before and after the change and compared across all 85 numeric datasets in the output file. Four of them differ, all far-field quantities derived from the FFT, by at most `3.5e-16` relative, which is one unit in the last place of a double. Those four differences are not attributable to this change: the identical datasets differ by the identical amounts when the same two binaries are compared on a deck containing no `&wake` namelist at all, so the changed line never executes, and running either binary twice reproduces itself exactly. This is `FieldSolverFFT` planning its transforms with `FFTW_MEASURE`, whose timing-based plan selection responds to any perturbation of the binary. Every `Beam` dataset, including `Beam/wakefield` and `Beam/energy`, is bit-identical.

## Acknowledgement

This fix and its verification were prepared with the assistance of Claude Opus 5, running in Claude Code. The model encountered the abort while porting the GPU backend to CUDA, established that it reproduces on the CPU-only path with no GPU involved and that the line responsible is untouched by that work, traced it to the read past the end of the vector, and set up the before-and-after runs quoted above, including the control that attributes the residual far-field differences to the FFTW planner rather than to the change. Every measurement was executed on real hardware, and I have reviewed the diagnosis and the change before submitting them. I would be glad to revise this if you would prefer a steady-state `&wake` to be refused outright instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
